### PR TITLE
fix(envs): allow Fluent custom vars in runtime validator

### DIFF
--- a/deploy/tools/envs-validator/schema.ts
+++ b/deploy/tools/envs-validator/schema.ts
@@ -136,6 +136,8 @@ const schema = yup
     NEXT_PUBLIC_USE_NEXT_JS_PROXY: yup.boolean(),
     NEXT_PUBLIC_API_KEYS_ALERT_MESSAGE: yup.string(),
     NEXT_PUBLIC_API_DOCS_ALERT_MESSAGE: yup.string(),
+    // deprecated, kept for backward compatibility to avoid runtime validation failures
+    NEXT_PUBLIC_API_SPEC_URL: yup.string().test(urlTest),
   })
   .concat(apisSchema)
   .concat(chainSchema)

--- a/deploy/tools/envs-validator/schema_multichain.ts
+++ b/deploy/tools/envs-validator/schema_multichain.ts
@@ -33,6 +33,8 @@ const schema = yup
     NEXT_PUBLIC_APP_PORT: yup.number().positive().integer(),
     NEXT_PUBLIC_APP_ENV: yup.string(),
     NEXT_PUBLIC_APP_INSTANCE: yup.string(),
+    // Fluent-specific chain selector (ignored in multichain mode but accepted for compatibility)
+    NEXT_PUBLIC_CHAIN: yup.string().oneOf([ 'mainnet', 'testnet', 'devnet' ]),
 
     // 2. Blockchain parameters
     NEXT_PUBLIC_NETWORK_NAME: yup.string().required(),
@@ -62,6 +64,8 @@ const schema = yup
 
     // Misc
     NEXT_PUBLIC_USE_NEXT_JS_PROXY: yup.boolean(),
+    // deprecated, accepted for compatibility
+    NEXT_PUBLIC_API_SPEC_URL: yup.string().test(urlTest),
   })
   .concat(uiSchemas.homepageSchema)
   .concat(uiSchemas.navigationSchema)

--- a/deploy/tools/envs-validator/schemas/chain.ts
+++ b/deploy/tools/envs-validator/schemas/chain.ts
@@ -6,6 +6,8 @@ import type { NetworkVerificationTypeEnvs } from 'types/networks';
 // Blockchain parameters schema
 export default yup.object({
     NEXT_PUBLIC_NETWORK_NAME: yup.string().required(),
+    // Fluent-specific chain selector used by configs/app/chain.ts
+    NEXT_PUBLIC_CHAIN: yup.string().oneOf([ 'mainnet', 'testnet', 'devnet' ]),
     NEXT_PUBLIC_NETWORK_SHORT_NAME: yup.string(),
     NEXT_PUBLIC_NETWORK_ID: yup.number().positive().integer().required(),
     NEXT_PUBLIC_NETWORK_RPC_URL: yup

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -106,6 +106,7 @@ Also, be aware that if you customize the name of the currency or any of its deno
 | Variable | Type| Description | Compulsoriness | Default value | Example value | Version |
 | --- | --- | --- | --- | --- | --- | --- |
 | NEXT_PUBLIC_NETWORK_NAME | `string` | Displayed name of the network | Required | - | `Gnosis Chain` | v1.0.x+ |
+| NEXT_PUBLIC_CHAIN | `mainnet \| testnet \| devnet` | Fluent-specific chain preset selector used by custom Fluent frontend logic. | - | `testnet` | `mainnet` | fluent-fork |
 | NEXT_PUBLIC_NETWORK_SHORT_NAME | `string` | Used for SEO attributes (e.g, page description) | - | -  | `OoG` | v1.0.x+ |
 | NEXT_PUBLIC_NETWORK_ID | `number` | Chain id, see [https://chainlist.org](https://chainlist.org) for the reference | Required (except for multichain) | -  | `99` | v1.0.x+ |
 | NEXT_PUBLIC_NETWORK_RPC_URL | `string \| Array<string>` | Chain public RPC server url, see [https://chainlist.org](https://chainlist.org) for the reference. Can contain a single string value, or an array of urls. | - | - | `https://core.poa.network` | v1.0.x+ |
@@ -595,6 +596,7 @@ Ads are enabled by default on all self-hosted instances. If you would like to di
 | --- | --- | --- | --- | --- | --- | --- |
 | NEXT_PUBLIC_API_DOCS_TABS | `Array<TabId>` | Controls which tabs appear on the API documentation page. Possible values for `TabId` are `rest_api`, `eth_rpc_api`, `rpc_api`, and `graphql_api`. **Note** that this variable has a default value, so the feature is enabled by default. Pass an empty array to disable it. | - | `['rest_api','eth_rpc_api','rpc_api','graphql_api']` | `[]` | v2.3.x+ |
 | NEXT_PUBLIC_API_DOCS_ALERT_MESSAGE | `string` | Used for displaying custom alerts on the API documentation page. Could be a regular string or a HTML code. | - | - | `Hello world! 🤪` | v2.7.0+ |
+| NEXT_PUBLIC_API_SPEC_URL | `string` | Deprecated compatibility variable. Accepted by runtime validator but ignored by current API docs implementation (spec URL is resolved from backend configuration). | - | - | `https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml` | fluent-fork |
 
 &nbsp;
 


### PR DESCRIPTION
## Summary

Fixes runtime ENV validation failure for Fluent fork custom variables:

- `NEXT_PUBLIC_CHAIN`
- `NEXT_PUBLIC_API_SPEC_URL`

The container failed with:

> Unknown ENV variables were provided: NEXT_PUBLIC_CHAIN, NEXT_PUBLIC_API_SPEC_URL

because env validator schemas use strict `noUnknown(true)` and these vars were not in the allowlist.

## Changes

- Added `NEXT_PUBLIC_CHAIN` allowlist support in chain schema:
  - `deploy/tools/envs-validator/schemas/chain.ts`
- Added compatibility support in multichain schema too:
  - `deploy/tools/envs-validator/schema_multichain.ts`
- Added deprecated compatibility allowlist for `NEXT_PUBLIC_API_SPEC_URL`:
  - `deploy/tools/envs-validator/schema.ts`
  - `deploy/tools/envs-validator/schema_multichain.ts`
- Documented both vars in `docs/ENVS.md` so placeholder registry generation includes them.

## Notes

- `NEXT_PUBLIC_API_SPEC_URL` is still deprecated/ignored by the current API docs implementation; this PR only prevents validator hard-fail for compatibility.
