### PR TITLE
feat: add runtime upgrades page with paginated event logs

### DIFF
--- a/lib/api/services/general/misc.ts
+++ b/lib/api/services/general/misc.ts
@@ -16,6 +16,7 @@ import type { NovesAccountHistoryResponse, NovesDescribeTxsResponse, NovesRespon
 import type {
   OptimisticL2DepositsItem,
 } from 'types/api/optimisticL2';
+import type { RuntimeUpgradeDetailsResponse, RuntimeUpgradesResponse } from 'types/api/runtimeUpgrades';
 import type { SearchRedirectResult, SearchResult, SearchResultFilters, SearchResultItem } from 'types/api/search';
 import type { HomeStats } from 'types/api/stats';
 import type {
@@ -252,6 +253,15 @@ export const GENERAL_API_MISC_RESOURCES = {
     path: '/api/v2/advanced-filters/csv',
   },
 
+  // RUNTIME UPGRADES
+  runtime_upgrades: {
+    path: '/api/v2/runtime-upgrades',
+  },
+  runtime_upgrade: {
+    path: '/api/v2/runtime-upgrades/:genesis_hash',
+    pathParams: [ 'genesis_hash' as const ],
+  },
+
   // CONFIGS
   config_backend: {
     path: '/api/v2/config/backend',
@@ -326,6 +336,8 @@ R extends 'general:deposits' ? DepositsResponse :
 R extends 'general:deposits_counters' ? DepositsCounters :
 R extends 'general:advanced_filter' ? AdvancedFilterResponse :
 R extends 'general:advanced_filter_methods' ? AdvancedFilterMethodsResponse :
+R extends 'general:runtime_upgrades' ? RuntimeUpgradesResponse :
+R extends 'general:runtime_upgrade' ? RuntimeUpgradeDetailsResponse :
 never;
 /* eslint-enable @stylistic/indent */
 

--- a/lib/hooks/useNavItems.tsx
+++ b/lib/hooks/useNavItems.tsx
@@ -89,6 +89,12 @@ export default function useNavItems(): ReturnType {
        icon: 'verified',
        isActive: pathname === '/verified-contracts',
      };
+    const runtimeUpgrades: NavItem = {
+      text: 'Runtime upgrades',
+      nextRoute: { pathname: '/runtime-upgrades' as const },
+      icon: 'operation',
+      isActive: pathname === '/runtime-upgrades',
+    };
     const nameLookup = config.features.nameServices?.isEnabled ? {
       text: 'Name services lookup',
       nextRoute: { pathname: '/name-domains' as const },
@@ -180,6 +186,7 @@ export default function useNavItems(): ReturnType {
           topAccounts,
           validators,
           verifiedContracts,
+          runtimeUpgrades,
           mudWorlds,
           nameLookup,
         ].filter(Boolean) as Array<NavItem>,
@@ -197,6 +204,7 @@ export default function useNavItems(): ReturnType {
           userOps,
           topAccounts,
           verifiedContracts,
+          runtimeUpgrades,
           nameLookup,
         ].filter(Boolean) as Array<NavItem>,
       ];
@@ -213,6 +221,7 @@ export default function useNavItems(): ReturnType {
           topAccounts,
           validators,
           verifiedContracts,
+          runtimeUpgrades,
           nameLookup,
         ].filter(Boolean) as Array<NavItem>,
       ];
@@ -228,6 +237,7 @@ export default function useNavItems(): ReturnType {
         topAccounts,
         validators,
         verifiedContracts,
+        runtimeUpgrades,
         nameLookup,
         ...(config.features.beaconChain.isEnabled ? [
           {

--- a/lib/metadata/__snapshots__/generate.spec.ts.snap
+++ b/lib/metadata/__snapshots__/generate.spec.ts.snap
@@ -3,21 +3,21 @@
 exports[`generates correct metadata for: > dynamic route 1`] = `
 {
   "canonical": undefined,
-  "description": "View transaction 0x12345 on Blockscout (Blockscout) Explorer",
+  "description": "View transaction 0x12345 on Fluent Devnet (Fluent Devnet) Explorer",
   "jsonLd": undefined,
   "opengraph": {
     "description": "",
     "imageUrl": "",
-    "title": "Blockscout transaction 0x12345 | Blockscout",
+    "title": "Fluent Devnet transaction 0x12345 | Blockscout",
   },
-  "title": "Blockscout transaction 0x12345 | Blockscout",
+  "title": "Fluent Devnet transaction 0x12345 | Blockscout",
 }
 `;
 
 exports[`generates correct metadata for: > dynamic route with API data 1`] = `
 {
   "canonical": undefined,
-  "description": "0x12345, balances and analytics on the Blockscout (Blockscout) Explorer",
+  "description": "0x12345, balances and analytics on the Fluent Devnet (Fluent Devnet) Explorer",
   "jsonLd": {
     "@context": "https://schema.org",
     "@type": "Product",
@@ -41,22 +41,22 @@ exports[`generates correct metadata for: > dynamic route with API data 1`] = `
   "opengraph": {
     "description": "",
     "imageUrl": "",
-    "title": "Blockscout USDT token details | Blockscout",
+    "title": "Fluent Devnet USDT token details | Blockscout",
   },
-  "title": "Blockscout USDT token details | Blockscout",
+  "title": "Fluent Devnet USDT token details | Blockscout",
 }
 `;
 
 exports[`generates correct metadata for: > static route 1`] = `
 {
   "canonical": "http://localhost:3000/txs",
-  "description": "Open-source block explorer by Blockscout. Search transactions, verify smart contracts, analyze addresses, and track network activity. Complete blockchain data and APIs for the Blockscout (Blockscout) Explorer network.",
+  "description": "Open-source block explorer by Blockscout. Search transactions, verify smart contracts, analyze addresses, and track network activity. Complete blockchain data and APIs for the Fluent Devnet (Fluent Devnet) Explorer network.",
   "jsonLd": undefined,
   "opengraph": {
     "description": "",
     "imageUrl": "http://localhost:3000/static/og_image.png",
-    "title": "Blockscout transactions - Blockscout explorer | Blockscout",
+    "title": "Fluent Devnet transactions - Fluent Devnet explorer | Blockscout",
   },
-  "title": "Blockscout transactions - Blockscout explorer | Blockscout",
+  "title": "Fluent Devnet transactions - Fluent Devnet explorer | Blockscout",
 }
 `;

--- a/lib/metadata/getPageOgType.ts
+++ b/lib/metadata/getPageOgType.ts
@@ -68,6 +68,7 @@ const OG_TYPE_DICT: Record<Route['pathname'], OGPageType> = {
   '/interop-messages': 'Root page',
   '/operations': 'Root page',
   '/operation/[id]': 'Regular page',
+  '/runtime-upgrades': 'Root page',
   '/cc/tx/[hash]': 'Regular page',
   '/cross-chain-tx/[id]': 'Regular page',
 
@@ -79,6 +80,7 @@ const OG_TYPE_DICT: Record<Route['pathname'], OGPageType> = {
   '/chain/[chain_slug]/block/countdown/[height]': 'Regular page',
   '/chain/[chain_slug]/csv-export': 'Regular page',
   '/chain/[chain_slug]/op/[hash]': 'Regular page',
+  '/chain/[chain_slug]/runtime-upgrades': 'Regular page',
   '/chain/[chain_slug]/token/[hash]': 'Regular page',
   '/chain/[chain_slug]/token/[hash]/instance/[id]': 'Regular page',
   '/chain/[chain_slug]/tx/[hash]': 'Regular page',

--- a/lib/metadata/templates/description.ts
+++ b/lib/metadata/templates/description.ts
@@ -71,6 +71,7 @@ const TEMPLATE_MAP: Record<Route['pathname'], string> = {
   '/interop-messages': DEFAULT_TEMPLATE,
   '/operations': DEFAULT_TEMPLATE,
   '/operation/[id]': DEFAULT_TEMPLATE,
+  '/runtime-upgrades': DEFAULT_TEMPLATE,
   '/cc/tx/[hash]': DEFAULT_TEMPLATE,
   '/cross-chain-tx/[id]': DEFAULT_TEMPLATE,
 
@@ -82,6 +83,7 @@ const TEMPLATE_MAP: Record<Route['pathname'], string> = {
   '/chain/[chain_slug]/block/countdown/[height]': DEFAULT_TEMPLATE,
   '/chain/[chain_slug]/csv-export': DEFAULT_TEMPLATE,
   '/chain/[chain_slug]/op/[hash]': DEFAULT_TEMPLATE,
+  '/chain/[chain_slug]/runtime-upgrades': DEFAULT_TEMPLATE,
   '/chain/[chain_slug]/token/[hash]': DEFAULT_TEMPLATE,
   '/chain/[chain_slug]/token/[hash]/instance/[id]': DEFAULT_TEMPLATE,
   '/chain/[chain_slug]/tx/[hash]': DEFAULT_TEMPLATE,

--- a/lib/metadata/templates/title.ts
+++ b/lib/metadata/templates/title.ts
@@ -73,6 +73,7 @@ const TEMPLATE_MAP: Record<Route['pathname'], string> = {
   '/interop-messages': '%network_name% interop messages',
   '/operations': '%network_name% operations',
   '/operation/[id]': '%network_name% operation %id%',
+  '/runtime-upgrades': '%network_name% runtime upgrades',
   '/cc/tx/[hash]': '%network_name% cross-chain transaction %hash% details',
   '/cross-chain-tx/[id]': '%network_name% cross-chain transaction %id% details',
 
@@ -84,6 +85,7 @@ const TEMPLATE_MAP: Record<Route['pathname'], string> = {
   '/chain/[chain_slug]/block/countdown/[height]': '%network_name% block %height% countdown',
   '/chain/[chain_slug]/csv-export': '%network_name% export data to CSV',
   '/chain/[chain_slug]/op/[hash]': '%network_name% user operation %hash% details',
+  '/chain/[chain_slug]/runtime-upgrades': '%network_name% runtime upgrades',
   '/chain/[chain_slug]/token/[hash]': '%network_name% token details',
   '/chain/[chain_slug]/token/[hash]/instance/[id]': '%network_name% token NFT instance',
   '/chain/[chain_slug]/tx/[hash]': '%network_name% transaction %hash% details',

--- a/lib/mixpanel/getPageType.ts
+++ b/lib/mixpanel/getPageType.ts
@@ -66,6 +66,7 @@ export const PAGE_TYPE_DICT: Record<Route['pathname'], string> = {
   '/interop-messages': 'Interop messages',
   '/operations': 'Operations',
   '/operation/[id]': 'Operation details',
+  '/runtime-upgrades': 'Runtime upgrades',
   '/cc/tx/[hash]': 'Cross-chain transaction details',
   '/cross-chain-tx/[id]': 'Cross-chain transaction details',
 
@@ -77,6 +78,7 @@ export const PAGE_TYPE_DICT: Record<Route['pathname'], string> = {
   '/chain/[chain_slug]/block/countdown/[height]': 'Chain block countdown',
   '/chain/[chain_slug]/csv-export': 'Chain export data to CSV',
   '/chain/[chain_slug]/op/[hash]': 'Chain user operation details',
+  '/chain/[chain_slug]/runtime-upgrades': 'Chain runtime upgrades',
   '/chain/[chain_slug]/token/[hash]': 'Chain token details',
   '/chain/[chain_slug]/token/[hash]/instance/[id]': 'Chain token NFT instance',
   '/chain/[chain_slug]/tx/[hash]': 'Chain transaction details',

--- a/nextjs/nextjs-routes.d.ts
+++ b/nextjs/nextjs-routes.d.ts
@@ -46,6 +46,7 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/chain/[chain_slug]/block/countdown", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/csv-export", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/op/[hash]", { "chain_slug": string; "hash": string }>
+    | DynamicRoute<"/chain/[chain_slug]/runtime-upgrades", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/token/[hash]", { "chain_slug": string; "hash": string }>
     | DynamicRoute<"/chain/[chain_slug]/token/[hash]/instance/[id]", { "chain_slug": string; "hash": string; "id": string }>
     | DynamicRoute<"/chain/[chain_slug]/tx/[hash]", { "chain_slug": string; "hash": string }>
@@ -78,6 +79,7 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/pools/[hash]", { "hash": string }>
     | StaticRoute<"/pools">
     | StaticRoute<"/public-tags/submit">
+    | StaticRoute<"/runtime-upgrades">
     | StaticRoute<"/search-results">
     | StaticRoute<"/sprite">
     | DynamicRoute<"/stats/[id]", { "id": string }>

--- a/nextjs/nextjs-routes.d.ts
+++ b/nextjs/nextjs-routes.d.ts
@@ -46,6 +46,7 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/chain/[chain_slug]/block/countdown", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/csv-export", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/op/[hash]", { "chain_slug": string; "hash": string }>
+    | DynamicRoute<"/chain/[chain_slug]/runtime-upgrades", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/token/[hash]", { "chain_slug": string; "hash": string }>
     | DynamicRoute<"/chain/[chain_slug]/token/[hash]/instance/[id]", { "chain_slug": string; "hash": string; "id": string }>
     | DynamicRoute<"/chain/[chain_slug]/tx/[hash]", { "chain_slug": string; "hash": string }>

--- a/nextjs/nextjs-routes.d.ts
+++ b/nextjs/nextjs-routes.d.ts
@@ -46,7 +46,6 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/chain/[chain_slug]/block/countdown", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/csv-export", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/op/[hash]", { "chain_slug": string; "hash": string }>
-    | DynamicRoute<"/chain/[chain_slug]/runtime-upgrades", { "chain_slug": string }>
     | DynamicRoute<"/chain/[chain_slug]/token/[hash]", { "chain_slug": string; "hash": string }>
     | DynamicRoute<"/chain/[chain_slug]/token/[hash]/instance/[id]", { "chain_slug": string; "hash": string; "id": string }>
     | DynamicRoute<"/chain/[chain_slug]/tx/[hash]", { "chain_slug": string; "hash": string }>

--- a/pages/runtime-upgrades.tsx
+++ b/pages/runtime-upgrades.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from 'next';
+import dynamic from 'next/dynamic';
+import React from 'react';
+
+import PageNextJs from 'nextjs/PageNextJs';
+
+const RuntimeUpgrades = dynamic(() => import('ui/pages/RuntimeUpgrades'), { ssr: false });
+
+const Page: NextPage = () => {
+  return (
+    <PageNextJs pathname="/runtime-upgrades">
+      <RuntimeUpgrades/>
+    </PageNextJs>
+  );
+};
+
+export default Page;
+
+export { base as getServerSideProps } from 'nextjs/getServerSideProps/main';

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -100,6 +100,13 @@ const config: PlaywrightTestConfig = defineConfig({
           // Mock for growthbook to test feature flags
           { find: 'lib/growthbook/useFeatureValue', replacement: './playwright/mocks/lib/growthbook/useFeatureValue.js' },
 
+          // Mock next/router for CT builds (avoids bundling Next internals in Vite)
+          { find: /^next\/router$/, replacement: './playwright/mocks/modules/next/router.js' },
+
+          // Mock Node fs module for CT bundling paths that still reference it indirectly
+          { find: /^fs$/, replacement: './playwright/mocks/modules/fs.js' },
+          { find: /^node:fs$/, replacement: './playwright/mocks/modules/fs.js' },
+
           // Mock for reCaptcha hook
           { find: 'ui/shared/reCaptcha/useReCaptcha', replacement: './playwright/mocks/ui/shared/recaptcha/useReCaptcha.js' },
 

--- a/playwright/index.ts
+++ b/playwright/index.ts
@@ -14,13 +14,15 @@ const NEXT_ROUTER_MOCK = {
 
 beforeMount(async({ hooksConfig }: { hooksConfig?: { router: typeof router } }) => {
   // Before mount, redefine useRouter to return mock value from test.
-
-  // @ts-ignore: I really want to redefine this property :)
-  // eslint-disable-next-line no-import-assign
-  router.useRouter = () => ({
+  const nextRouterState = {
     ...NEXT_ROUTER_MOCK,
     ...hooksConfig?.router,
-  });
+  };
+
+  const setRouterMock = (router as Record<string, unknown>).__setRouterMock;
+  if (typeof setRouterMock === 'function') {
+    (setRouterMock as (value: typeof nextRouterState) => void)(nextRouterState);
+  }
 
   // set current date
   MockDate.set('2022-11-11T12:00:00Z');

--- a/playwright/mocks/modules/fs.js
+++ b/playwright/mocks/modules/fs.js
@@ -1,0 +1,12 @@
+export function readFileSync() {
+  return '';
+}
+
+export function existsSync() {
+  return false;
+}
+
+export default {
+  readFileSync,
+  existsSync,
+};

--- a/playwright/mocks/modules/next/router.js
+++ b/playwright/mocks/modules/next/router.js
@@ -1,0 +1,23 @@
+const DEFAULT_ROUTER_MOCK = {
+  query: {},
+  pathname: '',
+  push: () => Promise.resolve(),
+  replace: () => Promise.resolve(),
+};
+
+let currentRouter = { ...DEFAULT_ROUTER_MOCK };
+
+export function __setRouterMock(router) {
+  currentRouter = {
+    ...DEFAULT_ROUTER_MOCK,
+    ...(router || {}),
+  };
+}
+
+export function useRouter() {
+  return currentRouter;
+}
+
+export default {
+  useRouter,
+};

--- a/types/api/log.ts
+++ b/types/api/log.ts
@@ -8,6 +8,8 @@ export interface Log {
   index: number;
   decoded: DecodedInput | null;
   transaction_hash: string | null;
+  block_number?: number;
+  block_hash?: string;
   block_timestamp: string | null;
 }
 

--- a/types/api/runtimeUpgrades.ts
+++ b/types/api/runtimeUpgrades.ts
@@ -1,0 +1,27 @@
+export interface RuntimeUpgradeVersion {
+  genesis_hash: string | null;
+  genesis_version: string | null;
+  upgrades_count: number;
+  latest_block_number?: number | null;
+  code_hash?: string | null;
+}
+
+export interface RuntimeUpgradesResponse {
+  items: Array<RuntimeUpgradeVersion>;
+}
+
+export interface RuntimeUpgrade {
+  block_number: number | null;
+  block_timestamp: string | null;
+  code_hash: string | null;
+  genesis_hash: string | null;
+  genesis_version: string | null;
+  log_index: number | null;
+  target_address_hash: string | null;
+  transaction_hash: string | null;
+}
+
+export interface RuntimeUpgradeDetailsResponse {
+  items: Array<RuntimeUpgrade>;
+  next_page_params: null;
+}

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -8,6 +8,7 @@ import { generateListStub } from 'stubs/utils';
 import { Badge } from 'toolkit/chakra/badge';
 import { Link } from 'toolkit/chakra/link';
 import { TableBody, TableCell, TableColumnHeader, TableHeaderSticky, TableRoot, TableRow } from 'toolkit/chakra/table';
+import { decodeRuntimeUpgradedLog, getRuntimeUpgradeLogsApiUrl, RUNTIME_UPGRADED_TOPIC, RUNTIME_UPGRADE_ADDRESS } from 'ui/runtimeUpgrades/utils';
 import ActionBar, { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
 import CopyToClipboard from 'ui/shared/CopyToClipboard';
 import DataListDisplay from 'ui/shared/DataListDisplay';
@@ -19,7 +20,6 @@ import PageTitle from 'ui/shared/Page/PageTitle';
 import Pagination from 'ui/shared/pagination/Pagination';
 import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
 import Time from 'ui/shared/time/Time';
-import { decodeRuntimeUpgradedLog, getRuntimeUpgradeLogsApiUrl, RUNTIME_UPGRADED_TOPIC, RUNTIME_UPGRADE_ADDRESS } from 'ui/runtimeUpgrades/utils';
 
 const RuntimeUpgrades = () => {
   const { data, isPlaceholderData, isError, pagination } = useQueryWithPages({
@@ -96,7 +96,12 @@ const RuntimeUpgrades = () => {
           </TableHeaderSticky>
           <TableBody>
             { rows.map(({ item, decoded }) => (
-              <RuntimeUpgradeTableRow key={ `${ item.transaction_hash || 'tx' }-${ item.index }` } item={ item } decoded={ decoded } isLoading={ isPlaceholderData }/>
+              <RuntimeUpgradeTableRow
+                key={ `${ item.transaction_hash || 'tx' }-${ item.index }` }
+                item={ item }
+                decoded={ decoded }
+                isLoading={ isPlaceholderData }
+              />
             )) }
           </TableBody>
         </TableRoot>
@@ -104,7 +109,12 @@ const RuntimeUpgrades = () => {
 
       <VStack hideFrom="lg" gap={ 3 } alignItems="stretch">
         { rows.map(({ item, decoded }) => (
-          <RuntimeUpgradeCard key={ `${ item.transaction_hash || 'tx' }-${ item.index }` } item={ item } decoded={ decoded } isLoading={ isPlaceholderData }/>
+          <RuntimeUpgradeCard
+            key={ `${ item.transaction_hash || 'tx' }-${ item.index }` }
+            item={ item }
+            decoded={ decoded }
+            isLoading={ isPlaceholderData }
+          />
         )) }
       </VStack>
     </>
@@ -175,7 +185,11 @@ const RuntimeUpgradeTableRow = ({ item, decoded, isLoading }: RuntimeUpgradeRowP
         <HashCell value={ decoded.codeHash } isLoading={ isLoading }/>
       </TableCell>
       <TableCell>
-        { item.block_timestamp ? <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/> : <Text color="text.secondary">—</Text> }
+        { item.block_timestamp ? (
+          <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
       </TableCell>
     </TableRow>
   );
@@ -191,15 +205,39 @@ const RuntimeUpgradeCard = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps
         </HStack>
 
         <RowLabel label="Block">
-          { typeof item.block_number === 'number' ? <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading }/> : <Text color="text.secondary">—</Text> }
+          { typeof item.block_number === 'number' ? (
+            <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading }/>
+          ) : (
+            <Text color="text.secondary">—</Text>
+          ) }
         </RowLabel>
 
         <RowLabel label="Transaction">
-          { item.transaction_hash ? <TxEntity hash={ item.transaction_hash } noIcon isLoading={ isLoading } truncation="constant" maxW="100%"/> : <Text color="text.secondary">—</Text> }
+          { item.transaction_hash ? (
+            <TxEntity
+              hash={ item.transaction_hash }
+              noIcon
+              isLoading={ isLoading }
+              truncation="constant"
+              maxW="100%"
+            />
+          ) : (
+            <Text color="text.secondary">—</Text>
+          ) }
         </RowLabel>
 
         <RowLabel label="Target address">
-          { decoded.targetAddress ? <AddressEntity address={{ hash: decoded.targetAddress }} noIcon isLoading={ isLoading } truncation="constant" maxW="100%"/> : <Text color="text.secondary">Unable to decode</Text> }
+          { decoded.targetAddress ? (
+            <AddressEntity
+              address={{ hash: decoded.targetAddress }}
+              noIcon
+              isLoading={ isLoading }
+              truncation="constant"
+              maxW="100%"
+            />
+          ) : (
+            <Text color="text.secondary">Unable to decode</Text>
+          ) }
         </RowLabel>
 
         <RowLabel label="Genesis version">
@@ -215,7 +253,11 @@ const RuntimeUpgradeCard = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps
         </RowLabel>
 
         <RowLabel label="Timestamp">
-          { item.block_timestamp ? <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/> : <Text color="text.secondary">—</Text> }
+          { item.block_timestamp ? (
+            <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
+          ) : (
+            <Text color="text.secondary">—</Text>
+          ) }
         </RowLabel>
       </VStack>
     </Box>

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, HStack, Text, VStack } from '@chakra-ui/react';
+import { Box, Flex, HStack, Text, useBreakpointValue, VStack } from '@chakra-ui/react';
 import React from 'react';
 
 import type { RuntimeUpgrade, RuntimeUpgradeVersion } from 'types/api/runtimeUpgrades';
@@ -25,6 +25,11 @@ import Time from 'ui/shared/time/Time';
 const RuntimeUpgrades = () => {
   const { data, isPending, isError } = useApiQuery('general:runtime_upgrades');
   const [ expandedValues, setExpandedValues ] = React.useState<Array<string>>([]);
+
+  const sourceContractTruncation = useBreakpointValue<'none' | 'constant'>({
+    base: 'constant',
+    md: 'none',
+  }) ?? 'none';
 
   const apiLogsUrl = React.useMemo(() => getRuntimeUpgradesApiUrl(), []);
 
@@ -59,14 +64,10 @@ const RuntimeUpgrades = () => {
         <AddressEntity
           address={{ hash: RUNTIME_UPGRADE_ADDRESS }}
           noIcon
-          truncation="constant"
-          maxW="400px"
+          truncation={ sourceContractTruncation }
+          maxW="800px"
           fontWeight={ 600 }
         />
-      </HStack>
-      <HStack gap={ 2 }>
-        <Text as="span">Event:</Text>
-        <Badge colorPalette="blue">RuntimeUpgraded</Badge>
       </HStack>
     </Flex>
   );
@@ -197,6 +198,18 @@ interface RuntimeUpgradeRowProps {
 
 const RuntimeUpgradeCard = ({ item, isLoading }: RuntimeUpgradeRowProps) => {
   const systemTag = getSystemContractTag(item.target_address_hash);
+  const targetAddressTruncation = useBreakpointValue<'none' | 'constant'>({
+    base: 'constant',
+    sm: 'constant',
+    md: 'none',
+    lg: 'none',
+    xl: 'constant',
+    '2xl': 'constant',
+    '3xl': 'constant',
+    '4xl': 'constant',
+    '5xl': 'constant',
+    '6xl': 'constant',
+  }) ?? 'none';
 
   return (
     <Box
@@ -205,108 +218,134 @@ const RuntimeUpgradeCard = ({ item, isLoading }: RuntimeUpgradeRowProps) => {
       borderRadius="lg"
       overflow="hidden"
       display="grid"
-      gridTemplateColumns={{ base: 'minmax(0, 1fr)', xl: 'repeat(2, minmax(0, 1fr))' }}
+      gridTemplateColumns={{
+        base: '120px minmax(0, 1fr)',
+        lg: '160px minmax(0, 1fr)',
+        xl: '160px minmax(0, 1fr) 160px minmax(0, 1fr)',
+      }}
     >
-      <VStack
-        alignItems="stretch"
-        gap={ 0 }
-        borderBottomWidth={{ base: '1px', xl: 0 }}
-        borderRightWidth={{ base: 0, xl: '1px' }}
-        borderColor="border.divider"
-      >
-        <RowLabel label="Target address">
-          { item.target_address_hash ? (
-            <VStack alignItems="flex-start" gap={ 1 }>
-              <AddressEntity
-                address={{ hash: item.target_address_hash }}
-                noIcon
-                isLoading={ isLoading }
-                truncation="constant"
-                maxW="100%"
-              />
-              { systemTag ? <Badge colorPalette="purple">{ systemTag }</Badge> : null }
-            </VStack>
-          ) : (
-            <Text color="text.secondary">—</Text>
-          ) }
-        </RowLabel>
-
-        <RowLabel label="Version">
-          <Text>{ item.genesis_version || '—' }</Text>
-        </RowLabel>
-
-        <RowLabel label="Genesis hash">
-          <HashCell value={ item.genesis_hash } isLoading={ isLoading }/>
-        </RowLabel>
-
-        <RowLabel label="Code hash">
-          <HashCell value={ item.code_hash } isLoading={ isLoading }/>
-        </RowLabel>
-      </VStack>
-
-      <VStack alignItems="stretch" gap={ 0 }>
-        <RowLabel label="Event">
-          <Text fontWeight={ 600 }>RuntimeUpgraded</Text>
-        </RowLabel>
-
-        <RowLabel label="Block">
-          { typeof item.block_number === 'number' ? (
-            <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading }/>
-          ) : (
-            <Text color="text.secondary">—</Text>
-          ) }
-        </RowLabel>
-
-        <RowLabel label="Log index">
-          { typeof item.log_index === 'number' ? (
-            <Text>{ item.log_index }</Text>
-          ) : (
-            <Text color="text.secondary">—</Text>
-          ) }
-        </RowLabel>
-
-        <RowLabel label="Transaction">
-          { item.transaction_hash ? (
-            <TxEntity
-              hash={ item.transaction_hash }
+      <RowLabel label="Target address" row={ 1 } column="left">
+        { item.target_address_hash ? (
+          <VStack alignItems="flex-start" gap={ 1 }>
+            <AddressEntity
+              address={{ hash: item.target_address_hash }}
               noIcon
               isLoading={ isLoading }
-              truncation="constant"
+              truncation={ targetAddressTruncation }
               maxW="100%"
             />
-          ) : (
-            <Text color="text.secondary">—</Text>
-          ) }
-        </RowLabel>
+            { systemTag ? <Badge colorPalette="purple">{ systemTag }</Badge> : null }
+          </VStack>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </RowLabel>
 
-        <RowLabel label="Timestamp">
-          { item.block_timestamp ? (
-            <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
-          ) : (
-            <Text color="text.secondary">—</Text>
-          ) }
-        </RowLabel>
-      </VStack>
+      <RowLabel label="Version" row={ 2 } column="left">
+        <Text>{ item.genesis_version || '—' }</Text>
+      </RowLabel>
+
+      <RowLabel label="Genesis hash" row={ 3 } column="left">
+        <HashCell value={ item.genesis_hash } isLoading={ isLoading }/>
+      </RowLabel>
+
+      <RowLabel label="Code hash" row={ 4 } column="left" isLastInColumn>
+        <HashCell value={ item.code_hash } isLoading={ isLoading }/>
+      </RowLabel>
+
+      <RowLabel label="Block" row={ 1 } column="right">
+        { typeof item.block_number === 'number' ? (
+          <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading }/>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </RowLabel>
+
+      <RowLabel label="Log index" row={ 2 } column="right">
+        { typeof item.log_index === 'number' ? (
+          <Text>{ item.log_index }</Text>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </RowLabel>
+
+      <RowLabel label="Transaction" row={ 3 } column="right">
+        { item.transaction_hash ? (
+          <TxEntity
+            hash={ item.transaction_hash }
+            noIcon
+            isLoading={ isLoading }
+            truncation="constant"
+            maxW="100%"
+          />
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </RowLabel>
+
+      <RowLabel label="Timestamp" row={ 4 } column="right" isLastInColumn isLast>
+        { item.block_timestamp ? (
+          <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </RowLabel>
     </Box>
   );
 };
 
-const RowLabel = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <Box
-    display="grid"
-    gridTemplateColumns={{ base: '120px minmax(0, 1fr)', lg: '160px minmax(0, 1fr)' }}
-    gap={ 3 }
-    alignItems="flex-start"
-    px={ 3 }
-    py={ 2 }
-    _notLast={{ borderBottomWidth: '1px', borderColor: 'border.divider' }}
-  >
-    <Text color="text.secondary" fontSize="sm" whiteSpace="nowrap">{ label }</Text>
-    <Box minW={ 0 }>
-      { children }
-    </Box>
-  </Box>
-);
+const RowLabel = ({
+  label,
+  children,
+  row,
+  column,
+  isLastInColumn,
+  isLast,
+}: {
+  label: string;
+  children: React.ReactNode;
+  row: number;
+  column: 'left' | 'right';
+  isLastInColumn?: boolean;
+  isLast?: boolean;
+}) => {
+  const labelColumn = column === 'left' ? '1' : '3';
+  const valueColumn = column === 'left' ? '2' : '4';
+  const borderBottomWidth = {
+    base: isLast ? 0 : '1px',
+    xl: isLastInColumn ? 0 : '1px',
+  };
+
+  return (
+    <>
+      <Text
+        color="text.secondary"
+        fontSize="sm"
+        whiteSpace="nowrap"
+        px={ 3 }
+        py={ 2 }
+        borderBottomWidth={ borderBottomWidth }
+        borderColor="border.divider"
+        gridColumn={{ xl: labelColumn }}
+        gridRow={{ xl: row }}
+      >
+        { label }
+      </Text>
+      <Box
+        minW={ 0 }
+        px={ 3 }
+        py={ 2 }
+        borderBottomWidth={ borderBottomWidth }
+        borderRightWidth={{ base: 0, xl: column === 'left' ? '1px' : 0 }}
+        borderColor="border.divider"
+        gridColumn={{ xl: valueColumn }}
+        gridRow={{ xl: row }}
+      >
+        { children }
+      </Box>
+    </>
+  );
+};
 
 const HashCell = ({ value, isLoading, noCopy }: { value: string | null; isLoading?: boolean; noCopy?: boolean }) => {
   if (!value) {

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -1,8 +1,11 @@
 import { Box, Flex, HStack, Text, VStack } from '@chakra-ui/react';
+import { useQueries } from '@tanstack/react-query';
 import React from 'react';
 
+import type { Block } from 'types/api/block';
 import type { Log } from 'types/api/log';
 
+import useApiFetch from 'lib/api/useApiFetch';
 import { LOG } from 'stubs/log';
 import { generateListStub } from 'stubs/utils';
 import { Badge } from 'toolkit/chakra/badge';
@@ -36,14 +39,45 @@ const RuntimeUpgrades = () => {
     },
   });
 
+  const apiFetch = useApiFetch();
   const apiLogsUrl = React.useMemo(() => getRuntimeUpgradeLogsApiUrl(), []);
+
+  const blockNumbers = React.useMemo(() => {
+    return Array.from(new Set((data?.items || [])
+      .map((item) => item.block_number)
+      .filter((blockNumber): blockNumber is number => typeof blockNumber === 'number')));
+  }, [ data?.items ]);
+
+  const blockQueries = useQueries({
+    queries: blockNumbers.map((blockNumber) => ({
+      queryKey: [ 'general:block', blockNumber ],
+      queryFn: () => apiFetch<'general:block', Block>('general:block', {
+        pathParams: { height_or_hash: String(blockNumber) },
+      }),
+      enabled: !isPlaceholderData,
+      staleTime: 5 * 60 * 1000,
+      retry: 1,
+    })),
+  });
+
+  const blockTimestamps = React.useMemo(() => {
+    return blockNumbers.reduce<Record<number, string>>((result, blockNumber, index) => {
+      const blockData = blockQueries[index]?.data;
+      const timestamp = blockData && 'timestamp' in blockData ? blockData.timestamp : null;
+      if (timestamp) {
+        result[blockNumber] = timestamp;
+      }
+      return result;
+    }, {});
+  }, [ blockNumbers, blockQueries ]);
 
   const rows = React.useMemo(() => {
     return (data?.items || []).map((item) => ({
       item,
       decoded: decodeRuntimeUpgradedLog(item),
+      timestamp: item.block_timestamp || (typeof item.block_number === 'number' ? blockTimestamps[item.block_number] : null),
     }));
-  }, [ data?.items ]);
+  }, [ blockTimestamps, data?.items ]);
 
   const actionBar = (
     <ActionBar mt={ -6 } showShadow justifyContent={{ base: 'space-between', lg: 'end' }}>
@@ -82,7 +116,7 @@ const RuntimeUpgrades = () => {
   const content = rows.length ? (
     <>
       <Box hideBelow="lg" overflowX="auto">
-        <TableRoot minW="1200px" tableLayout="fixed">
+        <TableRoot minW="1240px">
           <TableHeaderSticky top={ ACTION_BAR_HEIGHT_DESKTOP }>
             <TableRow>
               <TableColumnHeader w="150px">Block</TableColumnHeader>
@@ -95,11 +129,12 @@ const RuntimeUpgrades = () => {
             </TableRow>
           </TableHeaderSticky>
           <TableBody>
-            { rows.map(({ item, decoded }) => (
+            { rows.map(({ item, decoded, timestamp }) => (
               <RuntimeUpgradeTableRow
                 key={ `${ item.transaction_hash || 'tx' }-${ item.index }` }
                 item={ item }
                 decoded={ decoded }
+                timestamp={ timestamp }
                 isLoading={ isPlaceholderData }
               />
             )) }
@@ -108,11 +143,12 @@ const RuntimeUpgrades = () => {
       </Box>
 
       <VStack hideFrom="lg" gap={ 3 } alignItems="stretch">
-        { rows.map(({ item, decoded }) => (
+        { rows.map(({ item, decoded, timestamp }) => (
           <RuntimeUpgradeCard
             key={ `${ item.transaction_hash || 'tx' }-${ item.index }` }
             item={ item }
             decoded={ decoded }
+            timestamp={ timestamp }
             isLoading={ isPlaceholderData }
           />
         )) }
@@ -142,10 +178,11 @@ const RuntimeUpgrades = () => {
 interface RuntimeUpgradeRowProps {
   item: Log;
   decoded: ReturnType<typeof decodeRuntimeUpgradedLog>;
+  timestamp: string | null;
   isLoading?: boolean;
 }
 
-const RuntimeUpgradeTableRow = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps) => {
+const RuntimeUpgradeTableRow = ({ item, decoded, timestamp, isLoading }: RuntimeUpgradeRowProps) => {
   return (
     <TableRow>
       <TableCell>
@@ -185,8 +222,8 @@ const RuntimeUpgradeTableRow = ({ item, decoded, isLoading }: RuntimeUpgradeRowP
         <HashCell value={ decoded.codeHash } isLoading={ isLoading }/>
       </TableCell>
       <TableCell>
-        { item.block_timestamp ? (
-          <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
+        { timestamp ? (
+          <Time timestamp={ timestamp } format="DD MMM YYYY, HH:mm:ss"/>
         ) : (
           <Text color="text.secondary">—</Text>
         ) }
@@ -195,7 +232,7 @@ const RuntimeUpgradeTableRow = ({ item, decoded, isLoading }: RuntimeUpgradeRowP
   );
 };
 
-const RuntimeUpgradeCard = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps) => {
+const RuntimeUpgradeCard = ({ item, decoded, timestamp, isLoading }: RuntimeUpgradeRowProps) => {
   return (
     <Box borderWidth="1px" borderColor="border.divider" borderRadius="lg" p={ 4 }>
       <VStack alignItems="stretch" gap={ 2 }>
@@ -253,8 +290,8 @@ const RuntimeUpgradeCard = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps
         </RowLabel>
 
         <RowLabel label="Timestamp">
-          { item.block_timestamp ? (
-            <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
+          { timestamp ? (
+            <Time timestamp={ timestamp } format="DD MMM YYYY, HH:mm:ss"/>
           ) : (
             <Text color="text.secondary">—</Text>
           ) }
@@ -277,7 +314,7 @@ const HashCell = ({ value, isLoading }: { value: string | null; isLoading?: bool
   }
 
   return (
-    <HStack gap={ 1 } maxW="100%">
+    <HStack gap={ 1 } maxW="100%" whiteSpace="nowrap">
       <HashStringShorten hash={ value } type="long"/>
       <CopyToClipboard text={ value } isLoading={ isLoading } noTooltip/>
     </HStack>

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -1,21 +1,15 @@
 import { Box, Flex, HStack, Text, VStack } from '@chakra-ui/react';
-import { useQueries } from '@tanstack/react-query';
 import React from 'react';
 
-import type { Block } from 'types/api/block';
-import type { Log } from 'types/api/log';
+import type { RuntimeUpgrade, RuntimeUpgradeVersion } from 'types/api/runtimeUpgrades';
 
-import useApiFetch from 'lib/api/useApiFetch';
-import useApiInfiniteQuery from 'lib/api/useApiInfiniteQuery';
+import useApiQuery from 'lib/api/useApiQuery';
 import { AccordionItem, AccordionItemContent, AccordionItemTrigger, AccordionRoot } from 'toolkit/chakra/accordion';
 import { Badge } from 'toolkit/chakra/badge';
-import { Button } from 'toolkit/chakra/button';
 import { Link } from 'toolkit/chakra/link';
 import {
-  decodeRuntimeUpgradedLog,
-  getRuntimeUpgradeLogsApiUrl,
+  getRuntimeUpgradesApiUrl,
   getSystemContractTag,
-  RUNTIME_UPGRADED_TOPIC,
   RUNTIME_UPGRADE_ADDRESS,
 } from 'ui/runtimeUpgrades/utils';
 import ActionBar from 'ui/shared/ActionBar';
@@ -29,109 +23,25 @@ import PageTitle from 'ui/shared/Page/PageTitle';
 import Time from 'ui/shared/time/Time';
 
 const RuntimeUpgrades = () => {
-  const {
-    data,
-    isPending,
-    isError,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-  } = useApiInfiniteQuery({
-    resourceName: 'general:address_logs',
-    pathParams: { hash: RUNTIME_UPGRADE_ADDRESS },
-    queryParams: { topic: RUNTIME_UPGRADED_TOPIC },
-  });
+  const { data, isPending, isError } = useApiQuery('general:runtime_upgrades');
+  const [ expandedValues, setExpandedValues ] = React.useState<Array<string>>([]);
 
-  const apiFetch = useApiFetch();
-  const apiLogsUrl = React.useMemo(() => getRuntimeUpgradeLogsApiUrl(), []);
+  const apiLogsUrl = React.useMemo(() => getRuntimeUpgradesApiUrl(), []);
 
-  const handleLoadMoreClick = React.useCallback(() => {
-    void fetchNextPage();
-  }, [ fetchNextPage ]);
+  const entries = React.useMemo(() => {
+    return (data?.items || [])
+      .slice()
+      .sort((a, b) => (getRuntimeUpgradeLatestBlockNumber(b) || 0) - (getRuntimeUpgradeLatestBlockNumber(a) || 0));
+  }, [ data ]);
 
-  const items = React.useMemo(() => {
-    return data?.pages.flatMap((page) => page.items) || [];
-  }, [ data?.pages ]);
-
-  const blockNumbers = React.useMemo(() => {
-    return Array.from(new Set(items
-      .map((item) => item.block_number)
-      .filter((blockNumber): blockNumber is number => typeof blockNumber === 'number')));
-  }, [ items ]);
-
-  const blockQueries = useQueries({
-    queries: blockNumbers.map((blockNumber) => ({
-      queryKey: [ 'general:block', blockNumber ],
-      queryFn: () => apiFetch<'general:block', Block>('general:block', {
-        pathParams: { height_or_hash: String(blockNumber) },
-      }),
-      staleTime: 5 * 60 * 1000,
-      retry: 1,
-    })),
-  });
-
-  const blockTimestamps = React.useMemo(() => {
-    return blockNumbers.reduce<Record<number, string>>((result, blockNumber, index) => {
-      const blockData = blockQueries[index]?.data;
-      const timestamp = blockData && 'timestamp' in blockData ? blockData.timestamp : null;
-      if (timestamp) {
-        result[blockNumber] = timestamp;
-      }
-      return result;
-    }, {});
-  }, [ blockNumbers, blockQueries ]);
-
-  const rows = React.useMemo(() => {
-    return items.map((item) => {
-      const decoded = decodeRuntimeUpgradedLog(item);
-
-      return {
-        item,
-        decoded,
-        timestamp: item.block_timestamp || (typeof item.block_number === 'number' ? blockTimestamps[item.block_number] : null),
-        systemTag: getSystemContractTag(decoded.targetAddress),
-      };
-    });
-  }, [ blockTimestamps, items ]);
-
-  const groupedRows = React.useMemo(() => {
-    const groupsMap = new Map<string, Array<(typeof rows)[number]>>();
-
-    rows.forEach((row) => {
-      const key = row.decoded.genesisHash || '__unknown__';
-      const current = groupsMap.get(key);
-
-      if (current) {
-        current.push(row);
-      } else {
-        groupsMap.set(key, [ row ]);
-      }
-    });
-
-    return Array.from(groupsMap.entries())
-      .map(([ key, entries ]) => {
-        const versionSet = new Set(entries.map((entry) => entry.decoded.genesisVersion).filter(Boolean));
-        const codeHashSet = new Set(entries.map((entry) => entry.decoded.codeHash).filter(Boolean));
-        const latestBlockNumber = entries.reduce((max, entry) => {
-          return typeof entry.item.block_number === 'number' ? Math.max(max, entry.item.block_number) : max;
-        }, 0);
-
-        return {
-          key,
-          genesisHash: key === '__unknown__' ? null : key,
-          entries,
-          latestBlockNumber,
-          version: versionSet.size === 1 ? [ ...versionSet ][0] : null,
-          codeHash: codeHashSet.size === 1 ? [ ...codeHashSet ][0] : null,
-        };
-      })
-      .sort((a, b) => b.latestBlockNumber - a.latestBlockNumber);
-  }, [ rows ]);
+  const handleAccordionValueChange = React.useCallback(({ value }: { value: Array<string> }) => {
+    setExpandedValues(value);
+  }, []);
 
   const actionBar = (
     <ActionBar mt={ -6 } showShadow justifyContent={{ base: 'space-between', lg: 'end' }}>
       <Link href={ apiLogsUrl } external noIcon color="link.primary" fontWeight={ 500 }>
-        Download raw logs (JSON)
+        Download raw upgrades (JSON)
       </Link>
     </ActionBar>
   );
@@ -161,61 +71,27 @@ const RuntimeUpgrades = () => {
     </Flex>
   );
 
-  const content = groupedRows.length ? (
-    <VStack alignItems="stretch" gap={ 6 }>
-      <AccordionRoot display="flex" flexDirection="column" gap={ 4 }>
-        { groupedRows.map((group, index) => {
-          const isUnknownGenesis = !group.genesisHash;
+  const content = entries.length ? (
+    <AccordionRoot
+      display="flex"
+      flexDirection="column"
+      gap={ 4 }
+      value={ expandedValues }
+      onValueChange={ handleAccordionValueChange }
+    >
+      { entries.map((entry, index) => {
+        const value = getRuntimeUpgradeAccordionValue(entry, index);
 
-          return (
-            <AccordionItem key={ group.key } value={ group.key } borderWidth="1px" borderColor="border.divider" borderRadius="lg" overflow="hidden">
-              <AccordionItemTrigger px={ 4 } py={ 3 }>
-                <VStack alignItems="flex-start" flex={ 1 } gap={ 1 } mr={ 3 }>
-                  <HStack gap={ 2 } flexWrap="wrap">
-                    <Text fontWeight={ 700 }>Genesis hash</Text>
-                    { isUnknownGenesis ? (
-                      <Text color="text.secondary">Unknown</Text>
-                    ) : (
-                      <HashCell value={ group.genesisHash } noCopy/>
-                    ) }
-                    <Badge colorPalette="blue">{ group.entries.length } upgrades</Badge>
-                  </HStack>
-
-                  <HStack gap={ 3 } color="text.secondary" fontSize="sm" flexWrap="wrap">
-                    <Text>Version: { group.version || 'Mixed/unknown' }</Text>
-                    <Text>Code hash: { group.codeHash ? '' : 'Mixed/unknown' }</Text>
-                    { group.codeHash ? <HashCell value={ group.codeHash } noCopy/> : null }
-                  </HStack>
-                </VStack>
-              </AccordionItemTrigger>
-              <AccordionItemContent px={ 4 } pb={ 4 }>
-                <VStack alignItems="stretch" gap={ 3 }>
-                  { group.entries.map(({ item, decoded, timestamp, systemTag }) => (
-                    <RuntimeUpgradeCard
-                      key={ `${ item.transaction_hash || 'tx' }-${ item.index }-${ index }` }
-                      item={ item }
-                      decoded={ decoded }
-                      timestamp={ timestamp }
-                      systemTag={ systemTag }
-                    />
-                  )) }
-                </VStack>
-              </AccordionItemContent>
-            </AccordionItem>
-          );
-        }) }
-      </AccordionRoot>
-      { hasNextPage ? (
-        <Button
-          alignSelf="center"
-          loading={ isFetchingNextPage }
-          loadingText="Loading"
-          onClick={ handleLoadMoreClick }
-        >
-          Load more
-        </Button>
-      ) : null }
-    </VStack>
+        return (
+          <RuntimeUpgradeGroup
+            key={ value }
+            entry={ entry }
+            value={ value }
+            isOpen={ expandedValues.includes(value) }
+          />
+        );
+      }) }
+    </AccordionRoot>
   ) : null;
 
   return (
@@ -227,7 +103,7 @@ const RuntimeUpgrades = () => {
       />
       <DataListDisplay
         isError={ isError }
-        itemsNum={ rows.length }
+        itemsNum={ entries.length }
         emptyText={ isPending ? 'Loading runtime upgrades…' : 'There are no runtime upgrade events yet.' }
         actionBar={ actionBar }
       >
@@ -237,26 +113,109 @@ const RuntimeUpgrades = () => {
   );
 };
 
+interface RuntimeUpgradeGroupProps {
+  entry: RuntimeUpgradeVersion;
+  value: string;
+  isOpen: boolean;
+}
+
+const RuntimeUpgradeGroup = ({ entry, value, isOpen }: RuntimeUpgradeGroupProps) => {
+  const genesisHash = entry.genesis_hash;
+  const version = entry.genesis_version;
+  const codeHash = entry.code_hash;
+  const upgradesCount = entry.upgrades_count;
+
+  const detailsQuery = useApiQuery('general:runtime_upgrade', {
+    pathParams: { genesis_hash: genesisHash ?? undefined },
+    queryOptions: {
+      enabled: isOpen && Boolean(genesisHash),
+      staleTime: 5 * 60 * 1000,
+    },
+  });
+
+  const items = detailsQuery.data?.items || [];
+
+  const displayedUpgradesCount = upgradesCount ?? (detailsQuery.data ? items.length : null);
+  let detailsContent: React.ReactNode;
+
+  if (!genesisHash) {
+    detailsContent = <Text color="text.secondary">Genesis hash is unavailable.</Text>;
+  } else if (detailsQuery.isPending) {
+    detailsContent = <Text color="text.secondary">Loading runtime upgrades…</Text>;
+  } else if (detailsQuery.isError) {
+    detailsContent = <Text color="text.secondary">Unable to load runtime upgrades.</Text>;
+  } else if (items.length) {
+    detailsContent = (
+      <VStack alignItems="stretch" gap={ 3 }>
+        { items.map((item, index) => (
+          <RuntimeUpgradeCard
+            key={ `${ item.transaction_hash || 'tx' }-${ item.log_index }-${ index }` }
+            item={ item }
+          />
+        )) }
+      </VStack>
+    );
+  } else {
+    detailsContent = <Text color="text.secondary">There are no runtime upgrade events for this genesis hash.</Text>;
+  }
+
+  return (
+    <AccordionItem value={ value } borderWidth="1px" borderColor="border.divider" borderRadius="lg" overflow="hidden">
+      <AccordionItemTrigger px={ 4 } py={ 3 }>
+        <VStack alignItems="flex-start" flex={ 1 } gap={ 1 } mr={ 3 }>
+          <HStack gap={ 2 } flexWrap="wrap">
+            <Text fontWeight={ 700 }>Genesis hash</Text>
+            <HashCell value={ genesisHash } noCopy/>
+            { displayedUpgradesCount !== null ? <Badge colorPalette="blue">{ displayedUpgradesCount } upgrades</Badge> : null }
+          </HStack>
+
+          <HStack gap={ 3 } color="text.secondary" fontSize="sm" flexWrap="wrap">
+            <Text>Version: { version || 'Unknown' }</Text>
+            { codeHash ? <HashCell value={ codeHash } noCopy/> : null }
+          </HStack>
+        </VStack>
+      </AccordionItemTrigger>
+      <AccordionItemContent px={ 4 } pb={ 4 }>
+        { detailsContent }
+      </AccordionItemContent>
+    </AccordionItem>
+  );
+};
+
+function getRuntimeUpgradeAccordionValue(entry: RuntimeUpgradeVersion, index: number) {
+  return entry.genesis_hash || `runtime-upgrade-${ index }`;
+}
+
+function getRuntimeUpgradeLatestBlockNumber(entry: RuntimeUpgradeVersion) {
+  return entry.latest_block_number;
+}
+
 interface RuntimeUpgradeRowProps {
-  item: Log;
-  decoded: ReturnType<typeof decodeRuntimeUpgradedLog>;
-  timestamp: string | null;
-  systemTag: string | null;
+  item: RuntimeUpgrade;
   isLoading?: boolean;
 }
 
-const RuntimeUpgradeCard = ({ item, decoded, timestamp, systemTag, isLoading }: RuntimeUpgradeRowProps) => {
+const RuntimeUpgradeCard = ({ item, isLoading }: RuntimeUpgradeRowProps) => {
+  const systemTag = getSystemContractTag(item.target_address_hash);
+
   return (
     <Box borderWidth="1px" borderColor="border.divider" borderRadius="lg" p={ 4 }>
       <VStack alignItems="stretch" gap={ 2 }>
         <HStack justifyContent="space-between" alignItems="flex-start">
           <Text fontWeight={ 600 }>RuntimeUpgraded</Text>
-          <Badge colorPalette={ decoded.isDecoded ? 'green' : 'orange' }>{ decoded.isDecoded ? 'Decoded' : 'Partial' }</Badge>
         </HStack>
 
         <RowLabel label="Block">
           { typeof item.block_number === 'number' ? (
             <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading }/>
+          ) : (
+            <Text color="text.secondary">—</Text>
+          ) }
+        </RowLabel>
+
+        <RowLabel label="Log index">
+          { typeof item.log_index === 'number' ? (
+            <Text>{ item.log_index }</Text>
           ) : (
             <Text color="text.secondary">—</Text>
           ) }
@@ -277,10 +236,10 @@ const RuntimeUpgradeCard = ({ item, decoded, timestamp, systemTag, isLoading }: 
         </RowLabel>
 
         <RowLabel label="Target contract">
-          { decoded.targetAddress ? (
+          { item.target_address_hash ? (
             <VStack alignItems="flex-start" gap={ 1 }>
               <AddressEntity
-                address={{ hash: decoded.targetAddress }}
+                address={{ hash: item.target_address_hash }}
                 noIcon
                 isLoading={ isLoading }
                 truncation="constant"
@@ -289,25 +248,25 @@ const RuntimeUpgradeCard = ({ item, decoded, timestamp, systemTag, isLoading }: 
               { systemTag ? <Badge colorPalette="purple">{ systemTag }</Badge> : null }
             </VStack>
           ) : (
-            <Text color="text.secondary">Unable to decode</Text>
+            <Text color="text.secondary">—</Text>
           ) }
         </RowLabel>
 
         <RowLabel label="Genesis version">
-          <Text>{ decoded.genesisVersion || '—' }</Text>
+          <Text>{ item.genesis_version || '—' }</Text>
         </RowLabel>
 
         <RowLabel label="Genesis hash">
-          <HashCell value={ decoded.genesisHash } isLoading={ isLoading }/>
+          <HashCell value={ item.genesis_hash } isLoading={ isLoading }/>
         </RowLabel>
 
         <RowLabel label="Code hash">
-          <HashCell value={ decoded.codeHash } isLoading={ isLoading }/>
+          <HashCell value={ item.code_hash } isLoading={ isLoading }/>
         </RowLabel>
 
         <RowLabel label="Timestamp">
-          { timestamp ? (
-            <Time timestamp={ timestamp } format="DD MMM YYYY, HH:mm:ss"/>
+          { item.block_timestamp ? (
+            <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
           ) : (
             <Text color="text.secondary">—</Text>
           ) }

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -1,0 +1,245 @@
+import { Box, Flex, HStack, Text, VStack } from '@chakra-ui/react';
+import React from 'react';
+
+import type { Log } from 'types/api/log';
+
+import { LOG } from 'stubs/log';
+import { generateListStub } from 'stubs/utils';
+import { Badge } from 'toolkit/chakra/badge';
+import { Link } from 'toolkit/chakra/link';
+import { TableBody, TableCell, TableColumnHeader, TableHeaderSticky, TableRoot, TableRow } from 'toolkit/chakra/table';
+import ActionBar, { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
+import CopyToClipboard from 'ui/shared/CopyToClipboard';
+import DataListDisplay from 'ui/shared/DataListDisplay';
+import AddressEntity from 'ui/shared/entities/address/AddressEntity';
+import BlockEntity from 'ui/shared/entities/block/BlockEntity';
+import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import HashStringShorten from 'ui/shared/HashStringShorten';
+import PageTitle from 'ui/shared/Page/PageTitle';
+import Pagination from 'ui/shared/pagination/Pagination';
+import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
+import Time from 'ui/shared/time/Time';
+import { decodeRuntimeUpgradedLog, getRuntimeUpgradeLogsApiUrl, RUNTIME_UPGRADED_TOPIC, RUNTIME_UPGRADE_ADDRESS } from 'ui/runtimeUpgrades/utils';
+
+const RuntimeUpgrades = () => {
+  const { data, isPlaceholderData, isError, pagination } = useQueryWithPages({
+    resourceName: 'general:address_logs',
+    pathParams: { hash: RUNTIME_UPGRADE_ADDRESS },
+    queryParams: { topic: RUNTIME_UPGRADED_TOPIC },
+    options: {
+      placeholderData: generateListStub<'general:address_logs'>(LOG, 3, { next_page_params: {
+        block_number: 9005750,
+        index: 42,
+        items_count: 50,
+        transaction_index: 23,
+      } }),
+    },
+  });
+
+  const apiLogsUrl = React.useMemo(() => getRuntimeUpgradeLogsApiUrl(), []);
+
+  const rows = React.useMemo(() => {
+    return (data?.items || []).map((item) => ({
+      item,
+      decoded: decodeRuntimeUpgradedLog(item),
+    }));
+  }, [ data?.items ]);
+
+  const actionBar = (
+    <ActionBar mt={ -6 } showShadow justifyContent={{ base: 'space-between', lg: 'end' }}>
+      <Link href={ apiLogsUrl } external noIcon color="link.primary" fontWeight={ 500 }>
+        Download raw logs (JSON)
+      </Link>
+      <Pagination ml={{ base: 0, lg: 8 }} { ...pagination }/>
+    </ActionBar>
+  );
+
+  const titleSecondRow = (
+    <Flex
+      direction={{ base: 'column', lg: 'row' }}
+      gap={{ base: 2, lg: 4 }}
+      alignItems={{ base: 'flex-start', lg: 'center' }}
+      color="text.secondary"
+      fontSize="sm"
+    >
+      <HStack gap={ 2 }>
+        <Text as="span">Source contract:</Text>
+        <AddressEntity
+          address={{ hash: RUNTIME_UPGRADE_ADDRESS }}
+          noIcon
+          truncation="constant"
+          maxW="400px"
+          fontWeight={ 600 }
+        />
+      </HStack>
+      <HStack gap={ 2 }>
+        <Text as="span">Event:</Text>
+        <Badge colorPalette="blue">RuntimeUpgraded</Badge>
+      </HStack>
+    </Flex>
+  );
+
+  const content = rows.length ? (
+    <>
+      <Box hideBelow="lg" overflowX="auto">
+        <TableRoot minW="1200px" tableLayout="fixed">
+          <TableHeaderSticky top={ ACTION_BAR_HEIGHT_DESKTOP }>
+            <TableRow>
+              <TableColumnHeader w="150px">Block</TableColumnHeader>
+              <TableColumnHeader w="280px">Transaction</TableColumnHeader>
+              <TableColumnHeader w="280px">Target address</TableColumnHeader>
+              <TableColumnHeader w="220px">Genesis version</TableColumnHeader>
+              <TableColumnHeader w="250px">Genesis hash</TableColumnHeader>
+              <TableColumnHeader w="250px">Code hash</TableColumnHeader>
+              <TableColumnHeader w="170px">Timestamp</TableColumnHeader>
+            </TableRow>
+          </TableHeaderSticky>
+          <TableBody>
+            { rows.map(({ item, decoded }) => (
+              <RuntimeUpgradeTableRow key={ `${ item.transaction_hash || 'tx' }-${ item.index }` } item={ item } decoded={ decoded } isLoading={ isPlaceholderData }/>
+            )) }
+          </TableBody>
+        </TableRoot>
+      </Box>
+
+      <VStack hideFrom="lg" gap={ 3 } alignItems="stretch">
+        { rows.map(({ item, decoded }) => (
+          <RuntimeUpgradeCard key={ `${ item.transaction_hash || 'tx' }-${ item.index }` } item={ item } decoded={ decoded } isLoading={ isPlaceholderData }/>
+        )) }
+      </VStack>
+    </>
+  ) : null;
+
+  return (
+    <Box>
+      <PageTitle
+        title="Runtime upgrades"
+        secondRow={ titleSecondRow }
+        withTextAd
+      />
+      <DataListDisplay
+        isError={ isError }
+        itemsNum={ rows.length }
+        emptyText="There are no runtime upgrade events yet."
+        actionBar={ actionBar }
+      >
+        { content }
+      </DataListDisplay>
+    </Box>
+  );
+};
+
+interface RuntimeUpgradeRowProps {
+  item: Log;
+  decoded: ReturnType<typeof decodeRuntimeUpgradedLog>;
+  isLoading?: boolean;
+}
+
+const RuntimeUpgradeTableRow = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps) => {
+  return (
+    <TableRow>
+      <TableCell>
+        { typeof item.block_number === 'number' ? (
+          <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading } fontWeight={ 600 }/>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </TableCell>
+      <TableCell>
+        { item.transaction_hash ? (
+          <TxEntity hash={ item.transaction_hash } noIcon isLoading={ isLoading } truncation="constant" maxW="100%"/>
+        ) : (
+          <Text color="text.secondary">—</Text>
+        ) }
+      </TableCell>
+      <TableCell>
+        { decoded.targetAddress ? (
+          <AddressEntity
+            address={{ hash: decoded.targetAddress }}
+            noIcon
+            isLoading={ isLoading }
+            truncation="constant"
+            maxW="100%"
+          />
+        ) : (
+          <Text color="text.secondary">Unable to decode</Text>
+        ) }
+      </TableCell>
+      <TableCell>
+        <Text noOfLines={ 2 }>{ decoded.genesisVersion || '—' }</Text>
+      </TableCell>
+      <TableCell>
+        <HashCell value={ decoded.genesisHash } isLoading={ isLoading }/>
+      </TableCell>
+      <TableCell>
+        <HashCell value={ decoded.codeHash } isLoading={ isLoading }/>
+      </TableCell>
+      <TableCell>
+        { item.block_timestamp ? <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/> : <Text color="text.secondary">—</Text> }
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const RuntimeUpgradeCard = ({ item, decoded, isLoading }: RuntimeUpgradeRowProps) => {
+  return (
+    <Box borderWidth="1px" borderColor="border.divider" borderRadius="lg" p={ 4 }>
+      <VStack alignItems="stretch" gap={ 2 }>
+        <HStack justifyContent="space-between" alignItems="flex-start">
+          <Text fontWeight={ 600 }>RuntimeUpgraded</Text>
+          <Badge colorPalette={ decoded.isDecoded ? 'green' : 'orange' }>{ decoded.isDecoded ? 'Decoded' : 'Partial' }</Badge>
+        </HStack>
+
+        <RowLabel label="Block">
+          { typeof item.block_number === 'number' ? <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading }/> : <Text color="text.secondary">—</Text> }
+        </RowLabel>
+
+        <RowLabel label="Transaction">
+          { item.transaction_hash ? <TxEntity hash={ item.transaction_hash } noIcon isLoading={ isLoading } truncation="constant" maxW="100%"/> : <Text color="text.secondary">—</Text> }
+        </RowLabel>
+
+        <RowLabel label="Target address">
+          { decoded.targetAddress ? <AddressEntity address={{ hash: decoded.targetAddress }} noIcon isLoading={ isLoading } truncation="constant" maxW="100%"/> : <Text color="text.secondary">Unable to decode</Text> }
+        </RowLabel>
+
+        <RowLabel label="Genesis version">
+          <Text>{ decoded.genesisVersion || '—' }</Text>
+        </RowLabel>
+
+        <RowLabel label="Genesis hash">
+          <HashCell value={ decoded.genesisHash } isLoading={ isLoading }/>
+        </RowLabel>
+
+        <RowLabel label="Code hash">
+          <HashCell value={ decoded.codeHash } isLoading={ isLoading }/>
+        </RowLabel>
+
+        <RowLabel label="Timestamp">
+          { item.block_timestamp ? <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/> : <Text color="text.secondary">—</Text> }
+        </RowLabel>
+      </VStack>
+    </Box>
+  );
+};
+
+const RowLabel = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <Box>
+    <Text color="text.secondary" fontSize="sm" mb={ 1 }>{ label }</Text>
+    { children }
+  </Box>
+);
+
+const HashCell = ({ value, isLoading }: { value: string | null; isLoading?: boolean }) => {
+  if (!value) {
+    return <Text color="text.secondary">—</Text>;
+  }
+
+  return (
+    <HStack gap={ 1 } maxW="100%">
+      <HashStringShorten hash={ value } type="long"/>
+      <CopyToClipboard text={ value } isLoading={ isLoading } noTooltip/>
+    </HStack>
+  );
+};
+
+export default RuntimeUpgrades;

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -6,8 +6,6 @@ import type { Block } from 'types/api/block';
 import type { Log } from 'types/api/log';
 
 import useApiFetch from 'lib/api/useApiFetch';
-import { LOG } from 'stubs/log';
-import { generateListStub } from 'stubs/utils';
 import { AccordionItem, AccordionItemContent, AccordionItemTrigger, AccordionRoot } from 'toolkit/chakra/accordion';
 import { Badge } from 'toolkit/chakra/badge';
 import { Link } from 'toolkit/chakra/link';
@@ -31,18 +29,10 @@ import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
 import Time from 'ui/shared/time/Time';
 
 const RuntimeUpgrades = () => {
-  const { data, isPlaceholderData, isError, pagination } = useQueryWithPages({
+  const { data, isPlaceholderData, isPending, isError, pagination } = useQueryWithPages({
     resourceName: 'general:address_logs',
     pathParams: { hash: RUNTIME_UPGRADE_ADDRESS },
     queryParams: { topic: RUNTIME_UPGRADED_TOPIC },
-    options: {
-      placeholderData: generateListStub<'general:address_logs'>(LOG, 3, { next_page_params: {
-        block_number: 9005750,
-        index: 42,
-        items_count: 50,
-        transaction_index: 23,
-      } }),
-    },
   });
 
   const apiFetch = useApiFetch();
@@ -214,7 +204,7 @@ const RuntimeUpgrades = () => {
       <DataListDisplay
         isError={ isError }
         itemsNum={ rows.length }
-        emptyText="There are no runtime upgrade events yet."
+        emptyText={ isPending ? 'Loading runtime upgrades…' : 'There are no runtime upgrade events yet.' }
         actionBar={ actionBar }
       >
         { content }

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -6,8 +6,10 @@ import type { Block } from 'types/api/block';
 import type { Log } from 'types/api/log';
 
 import useApiFetch from 'lib/api/useApiFetch';
+import useApiInfiniteQuery from 'lib/api/useApiInfiniteQuery';
 import { AccordionItem, AccordionItemContent, AccordionItemTrigger, AccordionRoot } from 'toolkit/chakra/accordion';
 import { Badge } from 'toolkit/chakra/badge';
+import { Button } from 'toolkit/chakra/button';
 import { Link } from 'toolkit/chakra/link';
 import {
   decodeRuntimeUpgradedLog,
@@ -24,12 +26,17 @@ import BlockEntity from 'ui/shared/entities/block/BlockEntity';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
 import HashStringShorten from 'ui/shared/HashStringShorten';
 import PageTitle from 'ui/shared/Page/PageTitle';
-import Pagination from 'ui/shared/pagination/Pagination';
-import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
 import Time from 'ui/shared/time/Time';
 
 const RuntimeUpgrades = () => {
-  const { data, isPlaceholderData, isPending, isError, pagination } = useQueryWithPages({
+  const {
+    data,
+    isPending,
+    isError,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useApiInfiniteQuery({
     resourceName: 'general:address_logs',
     pathParams: { hash: RUNTIME_UPGRADE_ADDRESS },
     queryParams: { topic: RUNTIME_UPGRADED_TOPIC },
@@ -38,11 +45,19 @@ const RuntimeUpgrades = () => {
   const apiFetch = useApiFetch();
   const apiLogsUrl = React.useMemo(() => getRuntimeUpgradeLogsApiUrl(), []);
 
+  const handleLoadMoreClick = React.useCallback(() => {
+    void fetchNextPage();
+  }, [ fetchNextPage ]);
+
+  const items = React.useMemo(() => {
+    return data?.pages.flatMap((page) => page.items) || [];
+  }, [ data?.pages ]);
+
   const blockNumbers = React.useMemo(() => {
-    return Array.from(new Set((data?.items || [])
+    return Array.from(new Set(items
       .map((item) => item.block_number)
       .filter((blockNumber): blockNumber is number => typeof blockNumber === 'number')));
-  }, [ data?.items ]);
+  }, [ items ]);
 
   const blockQueries = useQueries({
     queries: blockNumbers.map((blockNumber) => ({
@@ -50,7 +65,6 @@ const RuntimeUpgrades = () => {
       queryFn: () => apiFetch<'general:block', Block>('general:block', {
         pathParams: { height_or_hash: String(blockNumber) },
       }),
-      enabled: !isPlaceholderData,
       staleTime: 5 * 60 * 1000,
       retry: 1,
     })),
@@ -68,7 +82,7 @@ const RuntimeUpgrades = () => {
   }, [ blockNumbers, blockQueries ]);
 
   const rows = React.useMemo(() => {
-    return (data?.items || []).map((item) => {
+    return items.map((item) => {
       const decoded = decodeRuntimeUpgradedLog(item);
 
       return {
@@ -78,7 +92,7 @@ const RuntimeUpgrades = () => {
         systemTag: getSystemContractTag(decoded.targetAddress),
       };
     });
-  }, [ blockTimestamps, data?.items ]);
+  }, [ blockTimestamps, items ]);
 
   const groupedRows = React.useMemo(() => {
     const groupsMap = new Map<string, Array<(typeof rows)[number]>>();
@@ -119,7 +133,6 @@ const RuntimeUpgrades = () => {
       <Link href={ apiLogsUrl } external noIcon color="link.primary" fontWeight={ 500 }>
         Download raw logs (JSON)
       </Link>
-      <Pagination ml={{ base: 0, lg: 8 }} { ...pagination }/>
     </ActionBar>
   );
 
@@ -149,49 +162,60 @@ const RuntimeUpgrades = () => {
   );
 
   const content = groupedRows.length ? (
-    <AccordionRoot display="flex" flexDirection="column" gap={ 4 }>
-      { groupedRows.map((group, index) => {
-        const isUnknownGenesis = !group.genesisHash;
+    <VStack alignItems="stretch" gap={ 6 }>
+      <AccordionRoot display="flex" flexDirection="column" gap={ 4 }>
+        { groupedRows.map((group, index) => {
+          const isUnknownGenesis = !group.genesisHash;
 
-        return (
-          <AccordionItem key={ group.key } value={ group.key } borderWidth="1px" borderColor="border.divider" borderRadius="lg" overflow="hidden">
-            <AccordionItemTrigger px={ 4 } py={ 3 }>
-              <VStack alignItems="flex-start" flex={ 1 } gap={ 1 } mr={ 3 }>
-                <HStack gap={ 2 } flexWrap="wrap">
-                  <Text fontWeight={ 700 }>Genesis hash</Text>
-                  { isUnknownGenesis ? (
-                    <Text color="text.secondary">Unknown</Text>
-                  ) : (
-                    <HashCell value={ group.genesisHash } noCopy isLoading={ isPlaceholderData }/>
-                  ) }
-                  <Badge colorPalette="blue">{ group.entries.length } upgrades</Badge>
-                </HStack>
+          return (
+            <AccordionItem key={ group.key } value={ group.key } borderWidth="1px" borderColor="border.divider" borderRadius="lg" overflow="hidden">
+              <AccordionItemTrigger px={ 4 } py={ 3 }>
+                <VStack alignItems="flex-start" flex={ 1 } gap={ 1 } mr={ 3 }>
+                  <HStack gap={ 2 } flexWrap="wrap">
+                    <Text fontWeight={ 700 }>Genesis hash</Text>
+                    { isUnknownGenesis ? (
+                      <Text color="text.secondary">Unknown</Text>
+                    ) : (
+                      <HashCell value={ group.genesisHash } noCopy/>
+                    ) }
+                    <Badge colorPalette="blue">{ group.entries.length } upgrades</Badge>
+                  </HStack>
 
-                <HStack gap={ 3 } color="text.secondary" fontSize="sm" flexWrap="wrap">
-                  <Text>Version: { group.version || 'Mixed/unknown' }</Text>
-                  <Text>Code hash: { group.codeHash ? '' : 'Mixed/unknown' }</Text>
-                  { group.codeHash ? <HashCell value={ group.codeHash } noCopy isLoading={ isPlaceholderData }/> : null }
-                </HStack>
-              </VStack>
-            </AccordionItemTrigger>
-            <AccordionItemContent px={ 4 } pb={ 4 }>
-              <VStack alignItems="stretch" gap={ 3 }>
-                { group.entries.map(({ item, decoded, timestamp, systemTag }) => (
-                  <RuntimeUpgradeCard
-                    key={ `${ item.transaction_hash || 'tx' }-${ item.index }-${ index }` }
-                    item={ item }
-                    decoded={ decoded }
-                    timestamp={ timestamp }
-                    systemTag={ systemTag }
-                    isLoading={ isPlaceholderData }
-                  />
-                )) }
-              </VStack>
-            </AccordionItemContent>
-          </AccordionItem>
-        );
-      }) }
-    </AccordionRoot>
+                  <HStack gap={ 3 } color="text.secondary" fontSize="sm" flexWrap="wrap">
+                    <Text>Version: { group.version || 'Mixed/unknown' }</Text>
+                    <Text>Code hash: { group.codeHash ? '' : 'Mixed/unknown' }</Text>
+                    { group.codeHash ? <HashCell value={ group.codeHash } noCopy/> : null }
+                  </HStack>
+                </VStack>
+              </AccordionItemTrigger>
+              <AccordionItemContent px={ 4 } pb={ 4 }>
+                <VStack alignItems="stretch" gap={ 3 }>
+                  { group.entries.map(({ item, decoded, timestamp, systemTag }) => (
+                    <RuntimeUpgradeCard
+                      key={ `${ item.transaction_hash || 'tx' }-${ item.index }-${ index }` }
+                      item={ item }
+                      decoded={ decoded }
+                      timestamp={ timestamp }
+                      systemTag={ systemTag }
+                    />
+                  )) }
+                </VStack>
+              </AccordionItemContent>
+            </AccordionItem>
+          );
+        }) }
+      </AccordionRoot>
+      { hasNextPage ? (
+        <Button
+          alignSelf="center"
+          loading={ isFetchingNextPage }
+          loadingText="Loading"
+          onClick={ handleLoadMoreClick }
+        >
+          Load more
+        </Button>
+      ) : null }
+    </VStack>
   ) : null;
 
   return (

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -199,11 +199,55 @@ const RuntimeUpgradeCard = ({ item, isLoading }: RuntimeUpgradeRowProps) => {
   const systemTag = getSystemContractTag(item.target_address_hash);
 
   return (
-    <Box borderWidth="1px" borderColor="border.divider" borderRadius="lg" p={ 4 }>
-      <VStack alignItems="stretch" gap={ 2 }>
-        <HStack justifyContent="space-between" alignItems="flex-start">
+    <Box
+      borderWidth="1px"
+      borderColor="border.divider"
+      borderRadius="lg"
+      overflow="hidden"
+      display="grid"
+      gridTemplateColumns={{ base: 'minmax(0, 1fr)', xl: 'repeat(2, minmax(0, 1fr))' }}
+    >
+      <VStack
+        alignItems="stretch"
+        gap={ 0 }
+        borderBottomWidth={{ base: '1px', xl: 0 }}
+        borderRightWidth={{ base: 0, xl: '1px' }}
+        borderColor="border.divider"
+      >
+        <RowLabel label="Target address">
+          { item.target_address_hash ? (
+            <VStack alignItems="flex-start" gap={ 1 }>
+              <AddressEntity
+                address={{ hash: item.target_address_hash }}
+                noIcon
+                isLoading={ isLoading }
+                truncation="constant"
+                maxW="100%"
+              />
+              { systemTag ? <Badge colorPalette="purple">{ systemTag }</Badge> : null }
+            </VStack>
+          ) : (
+            <Text color="text.secondary">—</Text>
+          ) }
+        </RowLabel>
+
+        <RowLabel label="Version">
+          <Text>{ item.genesis_version || '—' }</Text>
+        </RowLabel>
+
+        <RowLabel label="Genesis hash">
+          <HashCell value={ item.genesis_hash } isLoading={ isLoading }/>
+        </RowLabel>
+
+        <RowLabel label="Code hash">
+          <HashCell value={ item.code_hash } isLoading={ isLoading }/>
+        </RowLabel>
+      </VStack>
+
+      <VStack alignItems="stretch" gap={ 0 }>
+        <RowLabel label="Event">
           <Text fontWeight={ 600 }>RuntimeUpgraded</Text>
-        </HStack>
+        </RowLabel>
 
         <RowLabel label="Block">
           { typeof item.block_number === 'number' ? (
@@ -235,35 +279,6 @@ const RuntimeUpgradeCard = ({ item, isLoading }: RuntimeUpgradeRowProps) => {
           ) }
         </RowLabel>
 
-        <RowLabel label="Target contract">
-          { item.target_address_hash ? (
-            <VStack alignItems="flex-start" gap={ 1 }>
-              <AddressEntity
-                address={{ hash: item.target_address_hash }}
-                noIcon
-                isLoading={ isLoading }
-                truncation="constant"
-                maxW="100%"
-              />
-              { systemTag ? <Badge colorPalette="purple">{ systemTag }</Badge> : null }
-            </VStack>
-          ) : (
-            <Text color="text.secondary">—</Text>
-          ) }
-        </RowLabel>
-
-        <RowLabel label="Genesis version">
-          <Text>{ item.genesis_version || '—' }</Text>
-        </RowLabel>
-
-        <RowLabel label="Genesis hash">
-          <HashCell value={ item.genesis_hash } isLoading={ isLoading }/>
-        </RowLabel>
-
-        <RowLabel label="Code hash">
-          <HashCell value={ item.code_hash } isLoading={ isLoading }/>
-        </RowLabel>
-
         <RowLabel label="Timestamp">
           { item.block_timestamp ? (
             <Time timestamp={ item.block_timestamp } format="DD MMM YYYY, HH:mm:ss"/>
@@ -277,9 +292,19 @@ const RuntimeUpgradeCard = ({ item, isLoading }: RuntimeUpgradeRowProps) => {
 };
 
 const RowLabel = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <Box>
-    <Text color="text.secondary" fontSize="sm" mb={ 1 }>{ label }</Text>
-    { children }
+  <Box
+    display="grid"
+    gridTemplateColumns={{ base: '120px minmax(0, 1fr)', lg: '160px minmax(0, 1fr)' }}
+    gap={ 3 }
+    alignItems="flex-start"
+    px={ 3 }
+    py={ 2 }
+    _notLast={{ borderBottomWidth: '1px', borderColor: 'border.divider' }}
+  >
+    <Text color="text.secondary" fontSize="sm" whiteSpace="nowrap">{ label }</Text>
+    <Box minW={ 0 }>
+      { children }
+    </Box>
   </Box>
 );
 

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -8,11 +8,17 @@ import type { Log } from 'types/api/log';
 import useApiFetch from 'lib/api/useApiFetch';
 import { LOG } from 'stubs/log';
 import { generateListStub } from 'stubs/utils';
+import { AccordionItem, AccordionItemContent, AccordionItemTrigger, AccordionRoot } from 'toolkit/chakra/accordion';
 import { Badge } from 'toolkit/chakra/badge';
 import { Link } from 'toolkit/chakra/link';
-import { TableBody, TableCell, TableColumnHeader, TableHeaderSticky, TableRoot, TableRow } from 'toolkit/chakra/table';
-import { decodeRuntimeUpgradedLog, getRuntimeUpgradeLogsApiUrl, RUNTIME_UPGRADED_TOPIC, RUNTIME_UPGRADE_ADDRESS } from 'ui/runtimeUpgrades/utils';
-import ActionBar, { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
+import {
+  decodeRuntimeUpgradedLog,
+  getRuntimeUpgradeLogsApiUrl,
+  getSystemContractTag,
+  RUNTIME_UPGRADED_TOPIC,
+  RUNTIME_UPGRADE_ADDRESS,
+} from 'ui/runtimeUpgrades/utils';
+import ActionBar from 'ui/shared/ActionBar';
 import CopyToClipboard from 'ui/shared/CopyToClipboard';
 import DataListDisplay from 'ui/shared/DataListDisplay';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
@@ -72,12 +78,51 @@ const RuntimeUpgrades = () => {
   }, [ blockNumbers, blockQueries ]);
 
   const rows = React.useMemo(() => {
-    return (data?.items || []).map((item) => ({
-      item,
-      decoded: decodeRuntimeUpgradedLog(item),
-      timestamp: item.block_timestamp || (typeof item.block_number === 'number' ? blockTimestamps[item.block_number] : null),
-    }));
+    return (data?.items || []).map((item) => {
+      const decoded = decodeRuntimeUpgradedLog(item);
+
+      return {
+        item,
+        decoded,
+        timestamp: item.block_timestamp || (typeof item.block_number === 'number' ? blockTimestamps[item.block_number] : null),
+        systemTag: getSystemContractTag(decoded.targetAddress),
+      };
+    });
   }, [ blockTimestamps, data?.items ]);
+
+  const groupedRows = React.useMemo(() => {
+    const groupsMap = new Map<string, Array<(typeof rows)[number]>>();
+
+    rows.forEach((row) => {
+      const key = row.decoded.genesisHash || '__unknown__';
+      const current = groupsMap.get(key);
+
+      if (current) {
+        current.push(row);
+      } else {
+        groupsMap.set(key, [ row ]);
+      }
+    });
+
+    return Array.from(groupsMap.entries())
+      .map(([ key, entries ]) => {
+        const versionSet = new Set(entries.map((entry) => entry.decoded.genesisVersion).filter(Boolean));
+        const codeHashSet = new Set(entries.map((entry) => entry.decoded.codeHash).filter(Boolean));
+        const latestBlockNumber = entries.reduce((max, entry) => {
+          return typeof entry.item.block_number === 'number' ? Math.max(max, entry.item.block_number) : max;
+        }, 0);
+
+        return {
+          key,
+          genesisHash: key === '__unknown__' ? null : key,
+          entries,
+          latestBlockNumber,
+          version: versionSet.size === 1 ? [ ...versionSet ][0] : null,
+          codeHash: codeHashSet.size === 1 ? [ ...codeHashSet ][0] : null,
+        };
+      })
+      .sort((a, b) => b.latestBlockNumber - a.latestBlockNumber);
+  }, [ rows ]);
 
   const actionBar = (
     <ActionBar mt={ -6 } showShadow justifyContent={{ base: 'space-between', lg: 'end' }}>
@@ -113,47 +158,50 @@ const RuntimeUpgrades = () => {
     </Flex>
   );
 
-  const content = rows.length ? (
-    <>
-      <Box hideBelow="lg" overflowX="auto">
-        <TableRoot minW="1240px">
-          <TableHeaderSticky top={ ACTION_BAR_HEIGHT_DESKTOP }>
-            <TableRow>
-              <TableColumnHeader w="150px">Block</TableColumnHeader>
-              <TableColumnHeader w="280px">Transaction</TableColumnHeader>
-              <TableColumnHeader w="280px">Target address</TableColumnHeader>
-              <TableColumnHeader w="220px">Genesis version</TableColumnHeader>
-              <TableColumnHeader w="250px">Genesis hash</TableColumnHeader>
-              <TableColumnHeader w="250px">Code hash</TableColumnHeader>
-              <TableColumnHeader w="170px">Timestamp</TableColumnHeader>
-            </TableRow>
-          </TableHeaderSticky>
-          <TableBody>
-            { rows.map(({ item, decoded, timestamp }) => (
-              <RuntimeUpgradeTableRow
-                key={ `${ item.transaction_hash || 'tx' }-${ item.index }` }
-                item={ item }
-                decoded={ decoded }
-                timestamp={ timestamp }
-                isLoading={ isPlaceholderData }
-              />
-            )) }
-          </TableBody>
-        </TableRoot>
-      </Box>
+  const content = groupedRows.length ? (
+    <AccordionRoot display="flex" flexDirection="column" gap={ 4 }>
+      { groupedRows.map((group, index) => {
+        const isUnknownGenesis = !group.genesisHash;
 
-      <VStack hideFrom="lg" gap={ 3 } alignItems="stretch">
-        { rows.map(({ item, decoded, timestamp }) => (
-          <RuntimeUpgradeCard
-            key={ `${ item.transaction_hash || 'tx' }-${ item.index }` }
-            item={ item }
-            decoded={ decoded }
-            timestamp={ timestamp }
-            isLoading={ isPlaceholderData }
-          />
-        )) }
-      </VStack>
-    </>
+        return (
+          <AccordionItem key={ group.key } value={ group.key } borderWidth="1px" borderColor="border.divider" borderRadius="lg" overflow="hidden">
+            <AccordionItemTrigger px={ 4 } py={ 3 }>
+              <VStack alignItems="flex-start" flex={ 1 } gap={ 1 } mr={ 3 }>
+                <HStack gap={ 2 } flexWrap="wrap">
+                  <Text fontWeight={ 700 }>Genesis hash</Text>
+                  { isUnknownGenesis ? (
+                    <Text color="text.secondary">Unknown</Text>
+                  ) : (
+                    <HashCell value={ group.genesisHash } noCopy isLoading={ isPlaceholderData }/>
+                  ) }
+                  <Badge colorPalette="blue">{ group.entries.length } upgrades</Badge>
+                </HStack>
+
+                <HStack gap={ 3 } color="text.secondary" fontSize="sm" flexWrap="wrap">
+                  <Text>Version: { group.version || 'Mixed/unknown' }</Text>
+                  <Text>Code hash: { group.codeHash ? '' : 'Mixed/unknown' }</Text>
+                  { group.codeHash ? <HashCell value={ group.codeHash } noCopy isLoading={ isPlaceholderData }/> : null }
+                </HStack>
+              </VStack>
+            </AccordionItemTrigger>
+            <AccordionItemContent px={ 4 } pb={ 4 }>
+              <VStack alignItems="stretch" gap={ 3 }>
+                { group.entries.map(({ item, decoded, timestamp, systemTag }) => (
+                  <RuntimeUpgradeCard
+                    key={ `${ item.transaction_hash || 'tx' }-${ item.index }-${ index }` }
+                    item={ item }
+                    decoded={ decoded }
+                    timestamp={ timestamp }
+                    systemTag={ systemTag }
+                    isLoading={ isPlaceholderData }
+                  />
+                )) }
+              </VStack>
+            </AccordionItemContent>
+          </AccordionItem>
+        );
+      }) }
+    </AccordionRoot>
   ) : null;
 
   return (
@@ -179,60 +227,11 @@ interface RuntimeUpgradeRowProps {
   item: Log;
   decoded: ReturnType<typeof decodeRuntimeUpgradedLog>;
   timestamp: string | null;
+  systemTag: string | null;
   isLoading?: boolean;
 }
 
-const RuntimeUpgradeTableRow = ({ item, decoded, timestamp, isLoading }: RuntimeUpgradeRowProps) => {
-  return (
-    <TableRow>
-      <TableCell>
-        { typeof item.block_number === 'number' ? (
-          <BlockEntity number={ item.block_number } noIcon isLoading={ isLoading } fontWeight={ 600 }/>
-        ) : (
-          <Text color="text.secondary">—</Text>
-        ) }
-      </TableCell>
-      <TableCell>
-        { item.transaction_hash ? (
-          <TxEntity hash={ item.transaction_hash } noIcon isLoading={ isLoading } truncation="constant" maxW="100%"/>
-        ) : (
-          <Text color="text.secondary">—</Text>
-        ) }
-      </TableCell>
-      <TableCell>
-        { decoded.targetAddress ? (
-          <AddressEntity
-            address={{ hash: decoded.targetAddress }}
-            noIcon
-            isLoading={ isLoading }
-            truncation="constant"
-            maxW="100%"
-          />
-        ) : (
-          <Text color="text.secondary">Unable to decode</Text>
-        ) }
-      </TableCell>
-      <TableCell>
-        <Text lineClamp={ 2 }>{ decoded.genesisVersion || '—' }</Text>
-      </TableCell>
-      <TableCell>
-        <HashCell value={ decoded.genesisHash } isLoading={ isLoading }/>
-      </TableCell>
-      <TableCell>
-        <HashCell value={ decoded.codeHash } isLoading={ isLoading }/>
-      </TableCell>
-      <TableCell>
-        { timestamp ? (
-          <Time timestamp={ timestamp } format="DD MMM YYYY, HH:mm:ss"/>
-        ) : (
-          <Text color="text.secondary">—</Text>
-        ) }
-      </TableCell>
-    </TableRow>
-  );
-};
-
-const RuntimeUpgradeCard = ({ item, decoded, timestamp, isLoading }: RuntimeUpgradeRowProps) => {
+const RuntimeUpgradeCard = ({ item, decoded, timestamp, systemTag, isLoading }: RuntimeUpgradeRowProps) => {
   return (
     <Box borderWidth="1px" borderColor="border.divider" borderRadius="lg" p={ 4 }>
       <VStack alignItems="stretch" gap={ 2 }>
@@ -263,15 +262,18 @@ const RuntimeUpgradeCard = ({ item, decoded, timestamp, isLoading }: RuntimeUpgr
           ) }
         </RowLabel>
 
-        <RowLabel label="Target address">
+        <RowLabel label="Target contract">
           { decoded.targetAddress ? (
-            <AddressEntity
-              address={{ hash: decoded.targetAddress }}
-              noIcon
-              isLoading={ isLoading }
-              truncation="constant"
-              maxW="100%"
-            />
+            <VStack alignItems="flex-start" gap={ 1 }>
+              <AddressEntity
+                address={{ hash: decoded.targetAddress }}
+                noIcon
+                isLoading={ isLoading }
+                truncation="constant"
+                maxW="100%"
+              />
+              { systemTag ? <Badge colorPalette="purple">{ systemTag }</Badge> : null }
+            </VStack>
           ) : (
             <Text color="text.secondary">Unable to decode</Text>
           ) }
@@ -308,7 +310,7 @@ const RowLabel = ({ label, children }: { label: string; children: React.ReactNod
   </Box>
 );
 
-const HashCell = ({ value, isLoading }: { value: string | null; isLoading?: boolean }) => {
+const HashCell = ({ value, isLoading, noCopy }: { value: string | null; isLoading?: boolean; noCopy?: boolean }) => {
   if (!value) {
     return <Text color="text.secondary">—</Text>;
   }
@@ -316,7 +318,7 @@ const HashCell = ({ value, isLoading }: { value: string | null; isLoading?: bool
   return (
     <HStack gap={ 1 } maxW="100%" whiteSpace="nowrap">
       <HashStringShorten hash={ value } type="long"/>
-      <CopyToClipboard text={ value } isLoading={ isLoading } noTooltip/>
+      { noCopy ? null : <CopyToClipboard text={ value } isLoading={ isLoading } noTooltip/> }
     </HStack>
   );
 };

--- a/ui/pages/RuntimeUpgrades.tsx
+++ b/ui/pages/RuntimeUpgrades.tsx
@@ -176,7 +176,7 @@ const RuntimeUpgradeTableRow = ({ item, decoded, isLoading }: RuntimeUpgradeRowP
         ) }
       </TableCell>
       <TableCell>
-        <Text noOfLines={ 2 }>{ decoded.genesisVersion || '—' }</Text>
+        <Text lineClamp={ 2 }>{ decoded.genesisVersion || '—' }</Text>
       </TableCell>
       <TableCell>
         <HashCell value={ decoded.genesisHash } isLoading={ isLoading }/>

--- a/ui/runtimeUpgrades/utils.ts
+++ b/ui/runtimeUpgrades/utils.ts
@@ -1,0 +1,67 @@
+import { decodeAbiParameters, getAddress, slice } from 'viem';
+
+import type { Log } from 'types/api/log';
+
+import buildUrl from 'lib/api/buildUrl';
+
+export const RUNTIME_UPGRADE_ADDRESS = '0x0000000000000000000000000000000000520010';
+export const RUNTIME_UPGRADED_TOPIC = '0x2b9d873d8fe3cc1332bb875ae358b40fd305d1776ebe63cc80bac10fd3cf057b';
+
+const HASH_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+const runtimeUpgradedDataAbi = [
+  { name: 'genesis_version', type: 'string' },
+  { name: 'code_hash', type: 'bytes32' },
+] as const;
+
+export interface RuntimeUpgradeDecoded {
+  targetAddress: string | null;
+  genesisHash: string | null;
+  genesisVersion: string | null;
+  codeHash: string | null;
+  isDecoded: boolean;
+}
+
+export function decodeRuntimeUpgradedLog(log: Log): RuntimeUpgradeDecoded {
+  let targetAddress: string | null = null;
+  let genesisHash: string | null = null;
+  let genesisVersion: string | null = null;
+  let codeHash: string | null = null;
+
+  const targetAddressTopic = log.topics[1];
+  if (targetAddressTopic && HASH_32_REGEX.test(targetAddressTopic)) {
+    try {
+      targetAddress = getAddress(slice(targetAddressTopic as `0x${ string }`, 12));
+    } catch {
+      targetAddress = null;
+    }
+  }
+
+  const genesisHashTopic = log.topics[2];
+  if (genesisHashTopic && HASH_32_REGEX.test(genesisHashTopic)) {
+    genesisHash = genesisHashTopic;
+  }
+
+  if (typeof log.data === 'string' && log.data.startsWith('0x')) {
+    try {
+      const [ decodedGenesisVersion, decodedCodeHash ] = decodeAbiParameters(runtimeUpgradedDataAbi, log.data as `0x${ string }`);
+      genesisVersion = decodedGenesisVersion;
+      codeHash = decodedCodeHash;
+    } catch {
+      genesisVersion = null;
+      codeHash = null;
+    }
+  }
+
+  return {
+    targetAddress,
+    genesisHash,
+    genesisVersion,
+    codeHash,
+    isDecoded: Boolean(targetAddress && genesisHash && genesisVersion !== null && codeHash),
+  };
+}
+
+export function getRuntimeUpgradeLogsApiUrl() {
+  return buildUrl('general:address_logs', { hash: RUNTIME_UPGRADE_ADDRESS }, { topic: RUNTIME_UPGRADED_TOPIC }, true);
+}

--- a/ui/runtimeUpgrades/utils.ts
+++ b/ui/runtimeUpgrades/utils.ts
@@ -10,8 +10,14 @@ export const RUNTIME_UPGRADED_TOPIC = '0x2b9d873d8fe3cc1332bb875ae358b40fd305d17
 const HASH_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
 
 const runtimeUpgradedDataAbi = [
-  { name: 'genesis_version', type: 'string' },
-  { name: 'code_hash', type: 'bytes32' },
+  {
+    name: 'upgrade',
+    type: 'tuple',
+    components: [
+      { name: 'genesis_version', type: 'string' },
+      { name: 'code_hash', type: 'bytes32' },
+    ],
+  },
 ] as const;
 
 export interface RuntimeUpgradeDecoded {
@@ -44,9 +50,9 @@ export function decodeRuntimeUpgradedLog(log: Log): RuntimeUpgradeDecoded {
 
   if (typeof log.data === 'string' && log.data.startsWith('0x')) {
     try {
-      const [ decodedGenesisVersion, decodedCodeHash ] = decodeAbiParameters(runtimeUpgradedDataAbi, log.data as `0x${ string }`);
-      genesisVersion = decodedGenesisVersion;
-      codeHash = decodedCodeHash;
+      const [ decodedUpgrade ] = decodeAbiParameters(runtimeUpgradedDataAbi, log.data as `0x${ string }`);
+      genesisVersion = decodedUpgrade.genesis_version;
+      codeHash = decodedUpgrade.code_hash;
     } catch {
       genesisVersion = null;
       codeHash = null;

--- a/ui/runtimeUpgrades/utils.ts
+++ b/ui/runtimeUpgrades/utils.ts
@@ -20,6 +20,19 @@ const runtimeUpgradedDataAbi = [
   },
 ] as const;
 
+const SYSTEM_CONTRACT_TAGS_BY_ADDRESS: Record<string, string> = {
+  '0x0000000000000000000000000000000000520001': 'System Contract: EVM Runtime',
+  '0x0000000000000000000000000000000000520003': 'System Contract: SVM Runtime',
+  '0x0000000000000000000000000000000000520005': 'System Contract: WebAuthn Verifier',
+  '0x0000000000000000000000000000000000520006': 'System Contract: OAuth2 Verifier',
+  '0x0000000000000000000000000000000000520007': 'System Contract: Nitro Verifier',
+  '0x0000000000000000000000000000000000520008': 'System Contract: Universal Token Runtime',
+  '0x0000000000000000000000000000000000520009': 'System Contract: Wasm Runtime',
+  '0x0000000000000000000000000000000000520010': 'System Contract: Runtime Upgrade',
+  '0x9cacf613fc29015893728563f423fd26dcdb8ddc': 'System Contract: Rollup Bridge',
+  '0x0000000000000000000000000000000000520fee': 'System Contract: Fee Manager',
+};
+
 export interface RuntimeUpgradeDecoded {
   targetAddress: string | null;
   genesisHash: string | null;
@@ -66,6 +79,14 @@ export function decodeRuntimeUpgradedLog(log: Log): RuntimeUpgradeDecoded {
     codeHash,
     isDecoded: Boolean(targetAddress && genesisHash && genesisVersion !== null && codeHash),
   };
+}
+
+export function getSystemContractTag(address: string | null | undefined) {
+  if (!address) {
+    return null;
+  }
+
+  return SYSTEM_CONTRACT_TAGS_BY_ADDRESS[address.toLowerCase()] || null;
 }
 
 export function getRuntimeUpgradeLogsApiUrl() {

--- a/ui/runtimeUpgrades/utils.ts
+++ b/ui/runtimeUpgrades/utils.ts
@@ -1,24 +1,6 @@
-import { decodeAbiParameters, getAddress, slice } from 'viem';
-
-import type { Log } from 'types/api/log';
-
 import buildUrl from 'lib/api/buildUrl';
 
 export const RUNTIME_UPGRADE_ADDRESS = '0x0000000000000000000000000000000000520010';
-export const RUNTIME_UPGRADED_TOPIC = '0x2b9d873d8fe3cc1332bb875ae358b40fd305d1776ebe63cc80bac10fd3cf057b';
-
-const HASH_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
-
-const runtimeUpgradedDataAbi = [
-  {
-    name: 'upgrade',
-    type: 'tuple',
-    components: [
-      { name: 'genesis_version', type: 'string' },
-      { name: 'code_hash', type: 'bytes32' },
-    ],
-  },
-] as const;
 
 const SYSTEM_CONTRACT_TAGS_BY_ADDRESS: Record<string, string> = {
   '0x0000000000000000000000000000000000520001': 'System Contract: EVM Runtime',
@@ -33,54 +15,6 @@ const SYSTEM_CONTRACT_TAGS_BY_ADDRESS: Record<string, string> = {
   '0x0000000000000000000000000000000000520fee': 'System Contract: Fee Manager',
 };
 
-export interface RuntimeUpgradeDecoded {
-  targetAddress: string | null;
-  genesisHash: string | null;
-  genesisVersion: string | null;
-  codeHash: string | null;
-  isDecoded: boolean;
-}
-
-export function decodeRuntimeUpgradedLog(log: Log): RuntimeUpgradeDecoded {
-  let targetAddress: string | null = null;
-  let genesisHash: string | null = null;
-  let genesisVersion: string | null = null;
-  let codeHash: string | null = null;
-
-  const targetAddressTopic = log.topics[1];
-  if (targetAddressTopic && HASH_32_REGEX.test(targetAddressTopic)) {
-    try {
-      targetAddress = getAddress(slice(targetAddressTopic as `0x${ string }`, 12));
-    } catch {
-      targetAddress = null;
-    }
-  }
-
-  const genesisHashTopic = log.topics[2];
-  if (genesisHashTopic && HASH_32_REGEX.test(genesisHashTopic)) {
-    genesisHash = genesisHashTopic;
-  }
-
-  if (typeof log.data === 'string' && log.data.startsWith('0x')) {
-    try {
-      const [ decodedUpgrade ] = decodeAbiParameters(runtimeUpgradedDataAbi, log.data as `0x${ string }`);
-      genesisVersion = decodedUpgrade.genesis_version;
-      codeHash = decodedUpgrade.code_hash;
-    } catch {
-      genesisVersion = null;
-      codeHash = null;
-    }
-  }
-
-  return {
-    targetAddress,
-    genesisHash,
-    genesisVersion,
-    codeHash,
-    isDecoded: Boolean(targetAddress && genesisHash && genesisVersion !== null && codeHash),
-  };
-}
-
 export function getSystemContractTag(address: string | null | undefined) {
   if (!address) {
     return null;
@@ -89,6 +23,6 @@ export function getSystemContractTag(address: string | null | undefined) {
   return SYSTEM_CONTRACT_TAGS_BY_ADDRESS[address.toLowerCase()] || null;
 }
 
-export function getRuntimeUpgradeLogsApiUrl() {
-  return buildUrl('general:address_logs', { hash: RUNTIME_UPGRADE_ADDRESS }, { topic: RUNTIME_UPGRADED_TOPIC }, true);
+export function getRuntimeUpgradesApiUrl() {
+  return buildUrl('general:runtime_upgrades', undefined, undefined, true);
 }


### PR DESCRIPTION
## Summary
- add a new `/runtime-upgrades` page wired into the main Blockchain navigation
- fetch runtime upgrade logs from the runtime-upgrade system contract using topic filter
- decode `RuntimeUpgraded(address,bytes32,string,bytes32)` payload into readable fields
- render a useful desktop table + mobile cards with block/tx/target/genesis version/genesis hash/code hash/timestamp
- include pagination via existing `useQueryWithPages` (`next_page_params` backend flow)
- add a direct `Download raw logs (JSON)` link to the filtered API endpoint

## Technical notes
- source contract address: `0x0000000000000000000000000000000000520010`
- topic filter: `0x2b9d873d8fe3cc1332bb875ae358b40fd305d1776ebe63cc80bac10fd3cf057b`
- added optional `block_number`/`block_hash` fields to `types/api/log.ts` for API parity

## Validation
- pagination uses existing backend-compatible cursor flow from `/api/v2/addresses/:hash/logs`
- page is reachable from nav menu: Blockchain -> Runtime upgrades
