### PR TITLE
fix(build): unblock local build and add main GHCR publish workflow

### DIFF
--- a/.github/workflows/publish-image-main.yml
+++ b/.github/workflows/publish-image-main.yml
@@ -1,0 +1,49 @@
+name: Publish Docker image on main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-image-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Prepare image metadata
+        run: |
+          echo "SHORT_SHA=${GITHUB_SHA::8}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=$(echo "ghcr.io/${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}:${{ env.SHORT_SHA }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ env.SHORT_SHA }}
+            GIT_TAG=


### PR DESCRIPTION
## What this fixes

- Removes noisy local build warnings from `deploy/scripts/build_sprite.sh` by replacing `jq`-based registry generation with a Node-based implementation (no local `jq` dependency).
- Silences optional MetaMask React Native dependency resolution warning in web build via webpack alias in `next.config.js`.
- Restores missing multichain route page for runtime upgrades:
  - `pages/chain/[chain_slug]/runtime-upgrades/index.tsx`

## CI/CD

Adds `.github/workflows/publish-image-main.yml`:

- Trigger: push to `main`
- Registry: `ghcr.io`
- Image: `ghcr.io/${GITHUB_REPOSITORY}`
- Tag: short commit SHA (`${GITHUB_SHA::8}`)

## Validation

- `yarn build` passes locally (exit code 0).

## Notes

- Interpreted request `gchr.io` as `ghcr.io`.
