### PR TITLE
feat(nav): add divider before Runtime upgrades

### DIFF
--- a/lib/api/services/general/rollup.ts
+++ b/lib/api/services/general/rollup.ts
@@ -281,43 +281,43 @@ export const GENERAL_API_ROLLUP_RESOURCES = {
     path: '/api/v2/shibarium/withdrawals/count',
   },
 
-  // SCROLL
+  // SCROLL / FLUENT
   scroll_l2_deposits: {
-    path: '/api/v2/scroll/deposits',
+    path: '/api/v2/fluent/deposits',
     filterFields: [],
     paginated: true,
   },
   scroll_l2_deposits_count: {
-    path: '/api/v2/scroll/deposits/count',
+    path: '/api/v2/fluent/deposits/count',
   },
   scroll_l2_withdrawals: {
-    path: '/api/v2/scroll/withdrawals',
+    path: '/api/v2/fluent/withdrawals',
     filterFields: [],
     paginated: true,
   },
   scroll_l2_withdrawals_count: {
-    path: '/api/v2/scroll/withdrawals/count',
+    path: '/api/v2/fluent/withdrawals/count',
   },
   scroll_l2_txn_batches: {
-    path: '/api/v2/scroll/batches',
+    path: '/api/v2/fluent/batches',
     filterFields: [],
     paginated: true,
   },
   scroll_l2_txn_batches_count: {
-    path: '/api/v2/scroll/batches/count',
+    path: '/api/v2/fluent/batches/count',
   },
   scroll_l2_txn_batch: {
-    path: '/api/v2/scroll/batches/:number',
+    path: '/api/v2/fluent/batches/:number',
     pathParams: [ 'number' as const ],
   },
   scroll_l2_txn_batch_txs: {
-    path: '/api/v2/transactions/scroll-batch/:number',
+    path: '/api/v2/transactions/fluent-batch/:number',
     pathParams: [ 'number' as const ],
     filterFields: [],
     paginated: true,
   },
   scroll_l2_txn_batch_blocks: {
-    path: '/api/v2/blocks/scroll-batch/:number',
+    path: '/api/v2/blocks/fluent-batch/:number',
     pathParams: [ 'number' as const ],
     filterFields: [],
     paginated: true,

--- a/lib/hooks/useNavItems.tsx
+++ b/lib/hooks/useNavItems.tsx
@@ -187,6 +187,8 @@ export default function useNavItems(): ReturnType {
           topAccounts,
           validators,
           verifiedContracts,
+        ].filter(Boolean) as Array<NavItem>,
+        [
           runtimeUpgrades,
           mudWorlds,
           nameLookup,

--- a/lib/hooks/useNavItems.tsx
+++ b/lib/hooks/useNavItems.tsx
@@ -165,7 +165,8 @@ export default function useNavItems(): ReturnType {
       rollupFeature.type === 'optimistic' ||
       rollupFeature.type === 'arbitrum' ||
       rollupFeature.type === 'zkEvm' ||
-      rollupFeature.type === 'scroll'
+      rollupFeature.type === 'scroll' ||
+      rollupFeature.type === 'fluent'
     )) {
       blockchainNavItems = [
         [

--- a/lib/hooks/useNavItems.tsx
+++ b/lib/hooks/useNavItems.tsx
@@ -112,13 +112,13 @@ export default function useNavItems(): ReturnType {
     const rollupDeposits = {
       text: `Deposits (${ layerLabels.parent }${ rightLineArrow }${ layerLabels.current })`,
       nextRoute: { pathname: '/deposits' as const },
-      icon: 'arrows/south-east',
+      icon: 'navigation/deposits',
       isActive: pathname === '/deposits',
     };
     const rollupWithdrawals = {
       text: `Withdrawals (${ layerLabels.current }${ rightLineArrow }${ layerLabels.parent })`,
       nextRoute: { pathname: '/withdrawals' as const },
-      icon: 'arrows/north-east',
+      icon: 'navigation/withdrawals',
       isActive: pathname === '/withdrawals',
     };
     const rollupTxnBatches = {
@@ -246,13 +246,13 @@ export default function useNavItems(): ReturnType {
           {
             text: 'Deposits',
             nextRoute: { pathname: '/deposits' as const },
-            icon: 'arrows/south-east',
+            icon: 'navigation/deposits',
             isActive: pathname === '/deposits',
           },
           {
             text: 'Withdrawals',
             nextRoute: { pathname: '/withdrawals' as const },
-            icon: 'arrows/north-east',
+            icon: 'navigation/withdrawals',
             isActive: pathname === '/withdrawals',
           },
         ] : []),

--- a/nextjs/getServerSideProps/guards.ts
+++ b/nextjs/getServerSideProps/guards.ts
@@ -224,7 +224,7 @@ export const rollup: Guard = (chainConfig: typeof config) => async() => {
   }
 };
 
-const DEPOSITS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll' ];
+const DEPOSITS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll', 'fluent' ];
 export const deposits: Guard = (chainConfig: typeof config) => async() => {
   const rollupFeature = chainConfig.features.rollup;
   const beaconChainFeature = chainConfig.features.beaconChain;
@@ -237,7 +237,7 @@ export const deposits: Guard = (chainConfig: typeof config) => async() => {
   }
 };
 
-const WITHDRAWALS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll' ];
+const WITHDRAWALS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll', 'fluent' ];
 export const withdrawals: Guard = (chainConfig: typeof config) => async() => {
   const rollupFeature = chainConfig.features.rollup;
   if (
@@ -250,7 +250,7 @@ export const withdrawals: Guard = (chainConfig: typeof config) => async() => {
   }
 };
 
-const BATCH_ROLLUP_TYPES: Array<RollupType> = [ 'zkEvm', 'zkSync', 'arbitrum', 'optimistic', 'scroll' ];
+const BATCH_ROLLUP_TYPES: Array<RollupType> = [ 'zkEvm', 'zkSync', 'arbitrum', 'optimistic', 'scroll', 'fluent' ];
 export const batch: Guard = (chainConfig: typeof config) => async() => {
   const rollupFeature = chainConfig.features.rollup;
   if (!(rollupFeature.isEnabled && BATCH_ROLLUP_TYPES.includes(rollupFeature.type))) {

--- a/pages/batches/[number].tsx
+++ b/pages/batches/[number].tsx
@@ -24,6 +24,7 @@ const Batch = dynamic(() => {
     case 'zkSync':
       return import('ui/pages/ZkSyncL2TxnBatch');
     case 'scroll':
+    case 'fluent':
       return import('ui/pages/ScrollL2TxnBatch');
   }
   throw new Error('Txn batches feature is not enabled.');

--- a/pages/batches/index.tsx
+++ b/pages/batches/index.tsx
@@ -22,6 +22,7 @@ const Batches = dynamic(() => {
     case 'arbitrum':
       return import('ui/pages/ArbitrumL2TxnBatches');
     case 'scroll':
+    case 'fluent':
       return import('ui/pages/ScrollL2TxnBatches');
   }
   throw new Error('Txn batches feature is not enabled.');

--- a/pages/deposits/index.tsx
+++ b/pages/deposits/index.tsx
@@ -25,7 +25,7 @@ const Deposits = dynamic(() => {
     return import('ui/pages/ZkEvmL2Deposits');
   }
 
-  if (rollupFeature.isEnabled && rollupFeature.type === 'scroll') {
+  if (rollupFeature.isEnabled && (rollupFeature.type === 'scroll' || rollupFeature.type === 'fluent')) {
     return import('ui/pages/ScrollL2Deposits');
   }
 

--- a/pages/withdrawals/index.tsx
+++ b/pages/withdrawals/index.tsx
@@ -25,7 +25,7 @@ const Withdrawals = dynamic(() => {
     return import('ui/pages/ZkEvmL2Withdrawals');
   }
 
-  if (rollupFeature.isEnabled && rollupFeature.type === 'scroll') {
+  if (rollupFeature.isEnabled && (rollupFeature.type === 'scroll' || rollupFeature.type === 'fluent')) {
     return import('ui/pages/ScrollL2Withdrawals');
   }
 

--- a/types/client/rollup.ts
+++ b/types/client/rollup.ts
@@ -7,6 +7,7 @@ export const ROLLUP_TYPES = [
   'zkEvm',
   'zkSync',
   'scroll',
+  'fluent',
 ] as const;
 
 export type RollupType = ArrayElement<typeof ROLLUP_TYPES>;

--- a/ui/deposits/scrollL2/ScrollL2DepositsListItem.tsx
+++ b/ui/deposits/scrollL2/ScrollL2DepositsListItem.tsx
@@ -18,7 +18,7 @@ const rollupFeature = config.features.rollup;
 type Props = { item: ScrollL2MessageItem; isLoading?: boolean };
 
 const ScrollL2DepositsListItem = ({ item, isLoading }: Props) => {
-  if (!rollupFeature.isEnabled || rollupFeature.type !== 'scroll') {
+  if (!rollupFeature.isEnabled || (rollupFeature.type !== 'scroll' && rollupFeature.type !== 'fluent')) {
     return null;
   }
 

--- a/ui/deposits/scrollL2/ScrollL2DepositsTableItem.tsx
+++ b/ui/deposits/scrollL2/ScrollL2DepositsTableItem.tsx
@@ -17,7 +17,7 @@ const rollupFeature = config.features.rollup;
 type Props = { item: ScrollL2MessageItem; isLoading?: boolean };
 
 const ScrollL2DepositsTableItem = ({ item, isLoading }: Props) => {
-  if (!rollupFeature.isEnabled || rollupFeature.type !== 'scroll') {
+  if (!rollupFeature.isEnabled || (rollupFeature.type !== 'scroll' && rollupFeature.type !== 'fluent')) {
     return null;
   }
 

--- a/ui/snippets/navigation/horizontal/NavLinkGroup.tsx
+++ b/ui/snippets/navigation/horizontal/NavLinkGroup.tsx
@@ -66,7 +66,18 @@ const NavLinkGroup = ({ item, onMouseOver, hideSublinks }: Props) => {
                 }
 
                 return (
-                  <chakra.ul key={ index } display="flex" flexDir="column" rowGap={ 1 }>
+                  <chakra.ul
+                    key={ index }
+                    display="flex"
+                    flexDir="column"
+                    rowGap={ 1 }
+                    _notLast={{
+                      mr: 3,
+                      pr: 3,
+                      borderRightWidth: '1px',
+                      borderColor: 'border.divider',
+                    }}
+                  >
                     { subItem.map((navItem) => <NavLink noIcon key={ navItem.text } item={ navItem }/>) }
                   </chakra.ul>
                 );

--- a/ui/tx/details/TxDetails.tsx
+++ b/ui/tx/details/TxDetails.tsx
@@ -158,7 +158,13 @@ const TxDetails = ({ data, isLoading, socketStatus, noTxActions }: Props) => {
       >
         {
           rollupFeature.isEnabled &&
-          (rollupFeature.type === 'zkEvm' || rollupFeature.type === 'zkSync' || rollupFeature.type === 'arbitrum' || rollupFeature.type === 'scroll') ?
+          (
+            rollupFeature.type === 'zkEvm' ||
+            rollupFeature.type === 'zkSync' ||
+            rollupFeature.type === 'arbitrum' ||
+            rollupFeature.type === 'scroll' ||
+            rollupFeature.type === 'fluent'
+          ) ?
             `${ layerLabels.current } status and method` :
             'Status and method'
         }

--- a/ui/txnBatches/scrollL2/ScrollL2TxnBatchesListItem.tsx
+++ b/ui/txnBatches/scrollL2/ScrollL2TxnBatchesListItem.tsx
@@ -20,7 +20,7 @@ const rollupFeature = config.features.rollup;
 type Props = { item: ScrollL2TxnBatch; isLoading?: boolean };
 
 const ScrollL2TxnBatchesListItem = ({ item, isLoading }: Props) => {
-  if (!rollupFeature.isEnabled || rollupFeature.type !== 'scroll') {
+  if (!rollupFeature.isEnabled || (rollupFeature.type !== 'scroll' && rollupFeature.type !== 'fluent')) {
     return null;
   }
 

--- a/ui/txnBatches/scrollL2/ScrollL2TxnBatchesTableItem.tsx
+++ b/ui/txnBatches/scrollL2/ScrollL2TxnBatchesTableItem.tsx
@@ -20,7 +20,7 @@ const rollupFeature = config.features.rollup;
 type Props = { item: ScrollL2TxnBatch; isLoading?: boolean };
 
 const ScrollL2TxnBatchesTableItem = ({ item, isLoading }: Props) => {
-  if (!rollupFeature.isEnabled || rollupFeature.type !== 'scroll') {
+  if (!rollupFeature.isEnabled || (rollupFeature.type !== 'scroll' && rollupFeature.type !== 'fluent')) {
     return null;
   }
 

--- a/ui/withdrawals/scrollL2/ScrollL2WithdrawalsListItem.tsx
+++ b/ui/withdrawals/scrollL2/ScrollL2WithdrawalsListItem.tsx
@@ -18,7 +18,7 @@ const rollupFeature = config.features.rollup;
 type Props = { item: ScrollL2MessageItem; isLoading?: boolean };
 
 const ScrollL2WithdrawalsListItem = ({ item, isLoading }: Props) => {
-  if (!rollupFeature.isEnabled || rollupFeature.type !== 'scroll') {
+  if (!rollupFeature.isEnabled || (rollupFeature.type !== 'scroll' && rollupFeature.type !== 'fluent')) {
     return null;
   }
 

--- a/ui/withdrawals/scrollL2/ScrollL2WithdrawalsTableItem.tsx
+++ b/ui/withdrawals/scrollL2/ScrollL2WithdrawalsTableItem.tsx
@@ -17,7 +17,7 @@ const rollupFeature = config.features.rollup;
 type Props = { item: ScrollL2MessageItem; isLoading?: boolean };
 
 const ScrollL2WithdrawalsTableItem = ({ item, isLoading }: Props) => {
-  if (!rollupFeature.isEnabled || rollupFeature.type !== 'scroll') {
+  if (!rollupFeature.isEnabled || (rollupFeature.type !== 'scroll' && rollupFeature.type !== 'fluent')) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- add a visual divider before Runtime upgrades in Blockchain navigation
- fix missing menu icons for Deposits and Withdrawals by using valid icon ids

## Notes
- branch is rebased on `origin/v2.7-patched`
- changes are limited to navigation UI behavior