### PR TITLE
feat(wallet): fix Fluent addNetwork defaults for devnet

### DIFF
--- a/configs/app/fluent.ts
+++ b/configs/app/fluent.ts
@@ -10,7 +10,7 @@ export const DEVNET_EXPLORER_HOST = 'devnet.fluentscan.xyz';
 export const DEVNET_EXPLORER_URL = `https://${ DEVNET_EXPLORER_HOST }`;
 export const DEVNET_EXPLORER_API_HOST = 'api-devnet.fluentscan.xyz';
 export const DEVNET_EXPLORER_API_URL = `https://${ DEVNET_EXPLORER_API_HOST }`;
-export const DEVNET_RPC_URL = 'https://rpc.dev.gblend.xyz';
+export const DEVNET_RPC_URL = 'https://rpc.devnet.fluent.xyz';
 export const DEVNET_NETWORK_NAME = 'Fluent Developer Preview';
 
 export const MAINNET_NETWORK = 'fluent';

--- a/lib/web3/useAddChain.tsx
+++ b/lib/web3/useAddChain.tsx
@@ -2,12 +2,41 @@ import React from 'react';
 import type { AddEthereumChainParameter } from 'viem';
 
 import config from 'configs/app';
+import {
+  DEVNET_EXPLORER_URL,
+  FLUENT_DEVNET_CHAIN_ID,
+  FLUENT_MAINNET_CHAIN_ID,
+  FLUENT_TESTNET_CHAIN_ID,
+  MAINNET_EXPLORER_URL,
+  TESTNET_EXPLORER_URL,
+} from 'configs/app/fluent';
 import { useMultichainContext } from 'lib/contexts/multichain';
 import { SECOND } from 'toolkit/utils/consts';
 
 import useRewardsActivity from '../hooks/useRewardsActivity';
 import useProvider from './useProvider';
 import { getHexadecimalChainId } from './utils';
+
+const FLUENT_NETWORK_ICON = 'https://cdn.fluent.xyz/favicon.svg';
+
+function isFluentChain(chainConfig: typeof config) {
+  return chainConfig.chain.name.toLowerCase().includes('fluent');
+}
+
+function getDefaultBlockExplorerUrl(chainConfig: typeof config) {
+  const chainId = Number(chainConfig.chain.id);
+
+  switch (chainId) {
+    case FLUENT_DEVNET_CHAIN_ID:
+      return DEVNET_EXPLORER_URL;
+    case FLUENT_TESTNET_CHAIN_ID:
+      return TESTNET_EXPLORER_URL;
+    case FLUENT_MAINNET_CHAIN_ID:
+      return MAINNET_EXPLORER_URL;
+    default:
+      return chainConfig.app.baseUrl;
+  }
+}
 
 function getParams(chainConfig: typeof config): AddEthereumChainParameter {
   if (!chainConfig.chain.id) {
@@ -23,7 +52,8 @@ function getParams(chainConfig: typeof config): AddEthereumChainParameter {
       decimals: chainConfig.chain.currency.decimals ?? 18,
     },
     rpcUrls: chainConfig.chain.rpcUrls,
-    blockExplorerUrls: [ chainConfig.app.baseUrl ],
+    blockExplorerUrls: [ getDefaultBlockExplorerUrl(chainConfig) ],
+    iconUrls: isFluentChain(chainConfig) ? [ FLUENT_NETWORK_ICON ] : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- fix Fluent `wallet_addEthereumChain` defaults for devnet
- include Fluent network icon in addNetwork params

## What changed
- `configs/app/fluent.ts`
  - updated devnet default RPC URL:
    - from `https://rpc.dev.gblend.xyz`
    - to `https://rpc.devnet.fluent.xyz`

- `lib/web3/useAddChain.tsx`
  - for `wallet_addEthereumChain`, `blockExplorerUrls` now uses Fluent chain-specific defaults:
    - devnet → `https://devnet.fluentscan.xyz`
    - testnet → `https://testnet.fluentscan.xyz`
    - mainnet → `https://fluentscan.xyz`
  - keeps fallback to `chainConfig.app.baseUrl` for non-Fluent/unknown chains
  - includes Fluent icon URL in `iconUrls` for Fluent chains:
    - `https://cdn.fluent.xyz/favicon.svg`

## Notes
- base branch: `v2.7-patched`
- devnet values aligned with docs: https://docs.fluent.xyz/connect-to-fluent#fluent-devnet