### PR TITLE
feat(fluent): show verifier batches table on txn batches page

### DIFF
--- a/configs/app/apis.ts
+++ b/configs/app/apis.ts
@@ -176,6 +176,12 @@ const userOpsApi = (() => {
   });
 })();
 
+const verifierApi = (() => {
+  return Object.freeze({
+    endpoint: stripTrailingSlash(getEnvValue('NEXT_PUBLIC_VERIFIER_API_HOST') || generalApi.endpoint),
+  });
+})();
+
 const visualizeApi = (() => {
   const apiHost = getVisualizeApiHost();
   if (!apiHost) {
@@ -235,6 +241,7 @@ const apis: Apis = Object.freeze({
   stats: statsApi,
   tac: tacApi,
   userOps: userOpsApi,
+  verifier: verifierApi,
   visualize: visualizeApi,
   zetachain: zetachainApi,
 });

--- a/deploy/tools/envs-validator/schemas/apis.ts
+++ b/deploy/tools/envs-validator/schemas/apis.ts
@@ -20,6 +20,8 @@ export default yup.object({
 
     NEXT_PUBLIC_REWARDS_SERVICE_API_HOST: yup.string().test(urlTest),
 
+    NEXT_PUBLIC_VERIFIER_API_HOST: yup.string().test(urlTest),
+
     NEXT_PUBLIC_METADATA_SERVICE_API_HOST: yup
       .string()
       .test(urlTest),

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -132,6 +132,7 @@ Also, be aware that if you customize the name of the currency or any of its deno
 | NEXT_PUBLIC_API_HOST | `string` | Main API host | Required (except for multichain) | - | `blockscout.com` | v1.0.x+ |
 | NEXT_PUBLIC_EXPLORER_API_HOST | `string` | Fluent-specific explorer API host override. Takes priority over the API host resolved from `NEXT_PUBLIC_CHAIN` preset. | - | - | `api-testnet.fluentscan.xyz` | fluent-fork |
 | NEXT_PUBLIC_EXPLORER_API_URL | `string` | Fluent-specific explorer API endpoint URL override. Takes priority over the API URL resolved from `NEXT_PUBLIC_CHAIN` preset and is used by Stats/Visualize API defaults. | - | - | `https://api-testnet.fluentscan.xyz` | fluent-fork |
+| NEXT_PUBLIC_VERIFIER_API_HOST | `string` | Verifier service API endpoint URL for Fluent verifier batches page (`/verifier/v1/batches`). If not set, falls back to main API endpoint. | - | main API endpoint | `https://api.gblend.xyz` | fluent-fork |
 | NEXT_PUBLIC_API_PORT | `number` | Port where API is running on the host | - | - | `3001` | v1.0.x+ |
 | NEXT_PUBLIC_API_BASE_PATH | `string` | Base path for Main API endpoint url | - | - | `/poa/core` | v1.0.x+ |
 | NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL | `ws \| wss` | Main API websocket protocol | - | `wss` | `ws` | v1.0.x+ |

--- a/lib/api/resources.ts
+++ b/lib/api/resources.ts
@@ -38,6 +38,8 @@ import type {
 } from './services/tac-operation-lifecycle';
 import { USER_OPS_API_RESOURCES } from './services/userOps';
 import type { IsPaginated } from './services/utils';
+import type { VerifierApiResourceName, VerifierApiResourcePayload } from './services/verifier';
+import { VERIFIER_API_RESOURCES } from './services/verifier';
 import { VISUALIZE_API_RESOURCES } from './services/visualize';
 import type { VisualizeApiResourceName, VisualizeApiResourcePayload } from './services/visualize';
 import { ZETA_CHAIN_API_RESOURCES } from './services/zetaChain';
@@ -57,6 +59,7 @@ export const RESOURCES = {
   stats: STATS_API_RESOURCES,
   tac: TAC_OPERATION_LIFECYCLE_API_RESOURCES,
   userOps: USER_OPS_API_RESOURCES,
+  verifier: VERIFIER_API_RESOURCES,
   visualize: VISUALIZE_API_RESOURCES,
   zetachain: ZETA_CHAIN_API_RESOURCES,
   // external API resources
@@ -90,6 +93,7 @@ R extends MultichainStatsApiResourceName ? MultichainStatsApiResourcePayload<R> 
 R extends RewardsApiResourceName ? RewardsApiResourcePayload<R> :
 R extends StatsApiResourceName ? StatsApiResourcePayload<R> :
 R extends TacOperationLifecycleApiResourceName ? TacOperationLifecycleApiResourcePayload<R> :
+R extends VerifierApiResourceName ? VerifierApiResourcePayload<R> :
 R extends VisualizeApiResourceName ? VisualizeApiResourcePayload<R> :
 R extends ZetaChainApiResourceName ? ZetaChainApiResourcePayload<R> :
 never;

--- a/lib/api/services/verifier.ts
+++ b/lib/api/services/verifier.ts
@@ -1,0 +1,18 @@
+import type { ApiResource } from '../types';
+import type { VerifierBatchesResponse } from 'types/api/verifier';
+
+export const VERIFIER_API_RESOURCES = {
+  batches: {
+    path: '/verifier/v1/batches',
+    filterFields: [],
+    paginated: true,
+  },
+} satisfies Record<string, ApiResource>;
+
+export type VerifierApiResourceName = `verifier:${ keyof typeof VERIFIER_API_RESOURCES }`;
+
+/* eslint-disable @stylistic/indent */
+export type VerifierApiResourcePayload<R extends VerifierApiResourceName> =
+R extends 'verifier:batches' ? VerifierBatchesResponse :
+never;
+/* eslint-enable @stylistic/indent */

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -1,7 +1,7 @@
 export type ApiName =
 'general' | 'admin' | 'bens' | 'contractInfo' | 'clusters' | 'external' | 'interchainIndexer' |
 'metadata' | 'multichainAggregator' | 'multichainStats' | 'rewards' | 'stats' | 'tac' |
-'userOps' | 'visualize' | 'zetachain';
+'userOps' | 'verifier' | 'visualize' | 'zetachain';
 
 export interface ApiResource {
   path: string;

--- a/stubs/verifier.ts
+++ b/stubs/verifier.ts
@@ -1,0 +1,17 @@
+import type { VerifierBatch } from 'types/api/verifier';
+
+export const VERIFIER_BATCH: VerifierBatch = {
+  index: 273,
+  status: {
+    code: 1,
+    name: 'Committed',
+  },
+  batch_root: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  from_block_hash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+  to_block_hash: '0x3333333333333333333333333333333333333333333333333333333333333333',
+  start_block: 1697,
+  end_block: 1711,
+  block_count: 15,
+  l1_event_block: 4053979,
+  interval_resolved: true,
+};

--- a/types/api/verifier.ts
+++ b/types/api/verifier.ts
@@ -1,0 +1,31 @@
+export type VerifierBatchStatus = {
+  code: number;
+  name: string;
+};
+
+export type VerifierBatch = {
+  index: number;
+  status: VerifierBatchStatus;
+  batch_root: string;
+  from_block_hash: string;
+  to_block_hash: string;
+  start_block: number;
+  end_block: number;
+  block_count: number;
+  l1_event_block: number;
+  interval_resolved: boolean;
+};
+
+export type VerifierBatchesResponseRaw = {
+  items: Array<VerifierBatch>;
+  limit: number;
+  has_more: boolean;
+  next_cursor?: number | null;
+};
+
+export type VerifierBatchesResponse = VerifierBatchesResponseRaw & {
+  next_page_params: {
+    cursor: number;
+    limit: number;
+  } | null;
+};

--- a/ui/pages/FluentL2TxnBatches.tsx
+++ b/ui/pages/FluentL2TxnBatches.tsx
@@ -1,69 +1,76 @@
 import { Box, Text } from '@chakra-ui/react';
 import React from 'react';
 
-import useApiQuery from 'lib/api/useApiQuery';
-import { FLUENT_L2_TXN_BATCH } from 'stubs/fluentL2';
 import { generateListStub } from 'stubs/utils';
+import { VERIFIER_BATCH } from 'stubs/verifier';
 import { Skeleton } from 'toolkit/chakra/skeleton';
 import { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
 import DataListDisplay from 'ui/shared/DataListDisplay';
 import PageTitle from 'ui/shared/Page/PageTitle';
 import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
 import StickyPaginationWithText from 'ui/shared/StickyPaginationWithText';
-import ScrollL2TxnBatchesListItem from 'ui/txnBatches/scrollL2/ScrollL2TxnBatchesListItem';
-import ScrollL2TxnBatchesTable from 'ui/txnBatches/scrollL2/ScrollL2TxnBatchesTable';
+import FluentTxnBatchesListItem from 'ui/txnBatches/fluent/FluentTxnBatchesListItem';
+import FluentTxnBatchesTable from 'ui/txnBatches/fluent/FluentTxnBatchesTable';
+
+const PAGE_LIMIT = 50;
 
 const FluentL2TxnBatches = () => {
   const { data, isError, isPlaceholderData, pagination } = useQueryWithPages({
-    resourceName: 'general:fluent_l2_txn_batches',
+    resourceName: 'verifier:batches',
+    queryParams: {
+      limit: PAGE_LIMIT,
+    },
     options: {
-      placeholderData: generateListStub<'general:fluent_l2_txn_batches'>(
-        FLUENT_L2_TXN_BATCH,
-        50,
+      placeholderData: generateListStub<'verifier:batches'>(
+        VERIFIER_BATCH,
+        PAGE_LIMIT,
         {
+          limit: PAGE_LIMIT,
+          has_more: true,
+          next_cursor: 272,
           next_page_params: {
-            items_count: 50,
-            number: 224,
+            cursor: 272,
+            limit: PAGE_LIMIT,
           },
         },
       ),
-    },
-  });
-
-  const countersQuery = useApiQuery('general:fluent_l2_txn_batches_count', {
-    queryOptions: {
-      placeholderData: 123456,
+      select: (response) => ({
+        ...response,
+        next_page_params: response.has_more && typeof response.next_cursor === 'number' ? {
+          cursor: response.next_cursor,
+          limit: response.limit || PAGE_LIMIT,
+        } : null,
+      }),
     },
   });
 
   const content = data?.items ? (
     <>
       <Box hideFrom="lg">
-        { data.items.map(((item, index) => (
-          <ScrollL2TxnBatchesListItem
-            key={ item.number + (isPlaceholderData ? String(index) : '') }
+        { data.items.map((item, index) => (
+          <FluentTxnBatchesListItem
+            key={ item.index + (isPlaceholderData ? String(index) : '') }
             item={ item }
             isLoading={ isPlaceholderData }
           />
-        ))) }
+        )) }
       </Box>
       <Box hideBelow="lg">
-        <ScrollL2TxnBatchesTable items={ data.items } top={ pagination.isVisible ? ACTION_BAR_HEIGHT_DESKTOP : 0 } isLoading={ isPlaceholderData }/>
+        <FluentTxnBatchesTable items={ data.items } top={ pagination.isVisible ? ACTION_BAR_HEIGHT_DESKTOP : 0 } isLoading={ isPlaceholderData }/>
       </Box>
     </>
   ) : null;
 
   const text = (() => {
-    if (countersQuery.isError || isError || !data?.items.length) {
+    if (isError || !data?.items.length) {
       return null;
     }
 
     return (
-      <Skeleton loading={ countersQuery.isPlaceholderData || isPlaceholderData } display="flex" flexWrap="wrap">
+      <Skeleton loading={ isPlaceholderData } display="flex" flexWrap="wrap">
         Txn batch
-        <Text fontWeight={ 600 } whiteSpace="pre"> #{ data.items[0].number } </Text>to
-        <Text fontWeight={ 600 } whiteSpace="pre"> #{ data.items[data.items.length - 1].number } </Text>
-        (total of { countersQuery.data?.toLocaleString() } batches)
+        <Text fontWeight={ 600 } whiteSpace="pre"> #{ data.items[0].index } </Text>to
+        <Text fontWeight={ 600 } whiteSpace="pre"> #{ data.items[data.items.length - 1].index } </Text>
       </Skeleton>
     );
   })();

--- a/ui/txnBatches/fluent/FluentTxnBatchesListItem.tsx
+++ b/ui/txnBatches/fluent/FluentTxnBatchesListItem.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import type { VerifierBatch } from 'types/api/verifier';
+
+import { Skeleton } from 'toolkit/chakra/skeleton';
+import HashStringShortenDynamic from 'ui/shared/HashStringShortenDynamic';
+import ListItemMobileGrid from 'ui/shared/ListItemMobile/ListItemMobileGrid';
+
+import FluentVerifierBatchStatus from './FluentVerifierBatchStatus';
+
+type Props = {
+  item: VerifierBatch;
+  isLoading?: boolean;
+};
+
+const FluentTxnBatchesListItem = ({ item, isLoading }: Props) => {
+  return (
+    <ListItemMobileGrid.Container gridTemplateColumns="120px auto">
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Batch #</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">#{ item.index.toLocaleString() }</Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Status</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <FluentVerifierBatchStatus status={ item.status } isLoading={ isLoading }/>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Start block</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.start_block.toLocaleString() }</Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>End block</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.end_block.toLocaleString() }</Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Blocks</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.block_count.toLocaleString() }</Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L1 event block</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.l1_event_block.toLocaleString() }</Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Batch root</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">
+          <HashStringShortenDynamic hash={ item.batch_root } noTooltip/>
+        </Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>From hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">
+          <HashStringShortenDynamic hash={ item.from_block_hash } noTooltip/>
+        </Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>To hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">
+          <HashStringShortenDynamic hash={ item.to_block_hash } noTooltip/>
+        </Skeleton>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Resolved</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.interval_resolved ? 'Yes' : 'No' }</Skeleton>
+      </ListItemMobileGrid.Value>
+    </ListItemMobileGrid.Container>
+  );
+};
+
+export default React.memo(FluentTxnBatchesListItem);

--- a/ui/txnBatches/fluent/FluentTxnBatchesTable.tsx
+++ b/ui/txnBatches/fluent/FluentTxnBatchesTable.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import type { VerifierBatch } from 'types/api/verifier';
+
+import { TableBody, TableColumnHeader, TableHeaderSticky, TableRoot, TableRow } from 'toolkit/chakra/table';
+
+import FluentTxnBatchesTableItem from './FluentTxnBatchesTableItem';
+
+type Props = {
+  items: Array<VerifierBatch>;
+  top: number;
+  isLoading?: boolean;
+};
+
+const FluentTxnBatchesTable = ({ items, top, isLoading }: Props) => {
+  return (
+    <TableRoot tableLayout="auto" minW="1320px">
+      <TableHeaderSticky top={ top }>
+        <TableRow>
+          <TableColumnHeader>Batch #</TableColumnHeader>
+          <TableColumnHeader>Status</TableColumnHeader>
+          <TableColumnHeader>Batch root</TableColumnHeader>
+          <TableColumnHeader>From block hash</TableColumnHeader>
+          <TableColumnHeader>To block hash</TableColumnHeader>
+          <TableColumnHeader isNumeric>Start block</TableColumnHeader>
+          <TableColumnHeader isNumeric>End block</TableColumnHeader>
+          <TableColumnHeader isNumeric>Blocks</TableColumnHeader>
+          <TableColumnHeader isNumeric>L1 event block</TableColumnHeader>
+          <TableColumnHeader>Resolved</TableColumnHeader>
+        </TableRow>
+      </TableHeaderSticky>
+      <TableBody>
+        { items.map((item, index) => (
+          <FluentTxnBatchesTableItem
+            key={ item.index + (isLoading ? String(index) : '') }
+            item={ item }
+            isLoading={ isLoading }
+          />
+        )) }
+      </TableBody>
+    </TableRoot>
+  );
+};
+
+export default React.memo(FluentTxnBatchesTable);

--- a/ui/txnBatches/fluent/FluentTxnBatchesTableItem.tsx
+++ b/ui/txnBatches/fluent/FluentTxnBatchesTableItem.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import type { VerifierBatch } from 'types/api/verifier';
+
+import { Skeleton } from 'toolkit/chakra/skeleton';
+import { TableCell, TableRow } from 'toolkit/chakra/table';
+import HashStringShortenDynamic from 'ui/shared/HashStringShortenDynamic';
+
+import FluentVerifierBatchStatus from './FluentVerifierBatchStatus';
+
+type Props = {
+  item: VerifierBatch;
+  isLoading?: boolean;
+};
+
+const FluentTxnBatchesTableItem = ({ item, isLoading }: Props) => {
+  return (
+    <TableRow>
+      <TableCell verticalAlign="middle">
+        <Skeleton loading={ isLoading } display="inline-block">#{ item.index.toLocaleString() }</Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle">
+        <FluentVerifierBatchStatus status={ item.status } isLoading={ isLoading }/>
+      </TableCell>
+      <TableCell verticalAlign="middle" minW="220px">
+        <Skeleton loading={ isLoading } display="inline-block">
+          <HashStringShortenDynamic hash={ item.batch_root } noTooltip/>
+        </Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle" minW="220px">
+        <Skeleton loading={ isLoading } display="inline-block">
+          <HashStringShortenDynamic hash={ item.from_block_hash } noTooltip/>
+        </Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle" minW="220px">
+        <Skeleton loading={ isLoading } display="inline-block">
+          <HashStringShortenDynamic hash={ item.to_block_hash } noTooltip/>
+        </Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle" isNumeric>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.start_block.toLocaleString() }</Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle" isNumeric>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.end_block.toLocaleString() }</Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle" isNumeric>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.block_count.toLocaleString() }</Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle" isNumeric>
+        <Skeleton loading={ isLoading } display="inline-block">{ item.l1_event_block.toLocaleString() }</Skeleton>
+      </TableCell>
+      <TableCell verticalAlign="middle">
+        <Skeleton loading={ isLoading } display="inline-block">{ item.interval_resolved ? 'Yes' : 'No' }</Skeleton>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default React.memo(FluentTxnBatchesTableItem);

--- a/ui/txnBatches/fluent/FluentVerifierBatchStatus.tsx
+++ b/ui/txnBatches/fluent/FluentVerifierBatchStatus.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import type { VerifierBatchStatus } from 'types/api/verifier';
+
+import StatusTag from 'ui/shared/statusTag/StatusTag';
+
+interface Props {
+  status: VerifierBatchStatus;
+  isLoading?: boolean;
+}
+
+const FluentVerifierBatchStatus = ({ status, isLoading }: Props) => {
+  const normalized = status.name.toLowerCase();
+
+  if (normalized.includes('final')) {
+    return <StatusTag type="ok" text={ status.name } loading={ isLoading }/>;
+  }
+
+  if (normalized.includes('revert') || normalized.includes('invalid') || normalized.includes('fail')) {
+    return <StatusTag type="error" text={ status.name } loading={ isLoading }/>;
+  }
+
+  return <StatusTag type="pending" text={ status.name } loading={ isLoading }/>;
+};
+
+export default React.memo(FluentVerifierBatchStatus);


### PR DESCRIPTION
## Summary
Implement Fluent Txn batches page using verifier API endpoint with env-driven host.

## What changed
- Added new API namespace `verifier` and resource:
  - `verifier:batches` -> `GET /verifier/v1/batches`
- Added env config for verifier host in app config:
  - `NEXT_PUBLIC_VERIFIER_API_HOST`
  - Fallback behavior: if unset, uses main API endpoint
- Added env validator + docs entry for `NEXT_PUBLIC_VERIFIER_API_HOST`
- Reworked `ui/pages/FluentL2TxnBatches.tsx` to:
  - query `verifier:batches`
  - transform `next_cursor` + `has_more` into `next_page_params` for existing pagination hook
  - render mobile + desktop table with sticky pagination bar
- Added Fluent verifier batches UI components:
  - `ui/txnBatches/fluent/FluentTxnBatchesTable.tsx`
  - `ui/txnBatches/fluent/FluentTxnBatchesTableItem.tsx`
  - `ui/txnBatches/fluent/FluentTxnBatchesListItem.tsx`
  - `ui/txnBatches/fluent/FluentVerifierBatchStatus.tsx`
- Added typed verifier response model + stub:
  - `types/api/verifier.ts`
  - `stubs/verifier.ts`

## Endpoint expectations
Page now consumes:
- `${NEXT_PUBLIC_VERIFIER_API_HOST}/verifier/v1/batches?limit=50`

Response fields used:
- `items[]` with `index`, `status`, `batch_root`, `from_block_hash`, `to_block_hash`, `start_block`, `end_block`, `block_count`, `l1_event_block`, `interval_resolved`
- `has_more`, `next_cursor`, `limit`

## Validation
- `yarn -s lint:tsc`
- `yarn -s eslint --no-warn-ignored lib/api/types.ts configs/app/apis.ts lib/api/resources.ts lib/api/services/verifier.ts types/api/verifier.ts ui/pages/FluentL2TxnBatches.tsx ui/txnBatches/fluent/FluentVerifierBatchStatus.tsx ui/txnBatches/fluent/FluentTxnBatchesTable.tsx ui/txnBatches/fluent/FluentTxnBatchesTableItem.tsx ui/txnBatches/fluent/FluentTxnBatchesListItem.tsx stubs/verifier.ts`
