### PR TITLE
feat(fluent): improve verifier batch hashes and status tags

### DIFF
--- a/ui/txnBatches/fluent/FluentHashValue.tsx
+++ b/ui/txnBatches/fluent/FluentHashValue.tsx
@@ -1,0 +1,34 @@
+import { Flex } from '@chakra-ui/react';
+import React from 'react';
+
+import { Link } from 'toolkit/chakra/link';
+import CopyToClipboard from 'ui/shared/CopyToClipboard';
+import HashStringShorten from 'ui/shared/HashStringShorten';
+
+type Props = {
+  hash: string;
+  href?: string;
+};
+
+const FluentHashValue = ({ hash, href }: Props) => {
+  const value = (
+    <HashStringShorten
+      hash={ hash }
+      type="long"
+      noTooltip
+    />
+  );
+
+  return (
+    <Flex alignItems="center" minW={ 0 }>
+      { href ? (
+        <Link href={ href } minW={ 0 }>
+          { value }
+        </Link>
+      ) : value }
+      <CopyToClipboard text={ hash } noTooltip/>
+    </Flex>
+  );
+};
+
+export default React.memo(FluentHashValue);

--- a/ui/txnBatches/fluent/FluentTxnBatchesListItem.tsx
+++ b/ui/txnBatches/fluent/FluentTxnBatchesListItem.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import type { VerifierBatch } from 'types/api/verifier';
 
+import { route } from 'nextjs-routes';
+
 import { Skeleton } from 'toolkit/chakra/skeleton';
-import HashStringShortenDynamic from 'ui/shared/HashStringShortenDynamic';
 import ListItemMobileGrid from 'ui/shared/ListItemMobile/ListItemMobileGrid';
 
+import FluentHashValue from './FluentHashValue';
 import FluentVerifierBatchStatus from './FluentVerifierBatchStatus';
 
 type Props = {
@@ -49,21 +51,27 @@ const FluentTxnBatchesListItem = ({ item, isLoading }: Props) => {
       <ListItemMobileGrid.Label isLoading={ isLoading }>Batch root</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
         <Skeleton loading={ isLoading } display="inline-block">
-          <HashStringShortenDynamic hash={ item.batch_root } noTooltip/>
+          <FluentHashValue hash={ item.batch_root }/>
         </Skeleton>
       </ListItemMobileGrid.Value>
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>From hash</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
         <Skeleton loading={ isLoading } display="inline-block">
-          <HashStringShortenDynamic hash={ item.from_block_hash } noTooltip/>
+          <FluentHashValue
+            hash={ item.from_block_hash }
+            href={ route({ pathname: '/block/[height_or_hash]', query: { height_or_hash: item.from_block_hash } }) }
+          />
         </Skeleton>
       </ListItemMobileGrid.Value>
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>To hash</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
         <Skeleton loading={ isLoading } display="inline-block">
-          <HashStringShortenDynamic hash={ item.to_block_hash } noTooltip/>
+          <FluentHashValue
+            hash={ item.to_block_hash }
+            href={ route({ pathname: '/block/[height_or_hash]', query: { height_or_hash: item.to_block_hash } }) }
+          />
         </Skeleton>
       </ListItemMobileGrid.Value>
 

--- a/ui/txnBatches/fluent/FluentTxnBatchesTableItem.tsx
+++ b/ui/txnBatches/fluent/FluentTxnBatchesTableItem.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import type { VerifierBatch } from 'types/api/verifier';
 
+import { route } from 'nextjs-routes';
+
 import { Skeleton } from 'toolkit/chakra/skeleton';
 import { TableCell, TableRow } from 'toolkit/chakra/table';
-import HashStringShortenDynamic from 'ui/shared/HashStringShortenDynamic';
 
+import FluentHashValue from './FluentHashValue';
 import FluentVerifierBatchStatus from './FluentVerifierBatchStatus';
 
 type Props = {
@@ -24,17 +26,23 @@ const FluentTxnBatchesTableItem = ({ item, isLoading }: Props) => {
       </TableCell>
       <TableCell verticalAlign="middle" minW="220px">
         <Skeleton loading={ isLoading } display="inline-block">
-          <HashStringShortenDynamic hash={ item.batch_root } noTooltip/>
+          <FluentHashValue hash={ item.batch_root }/>
         </Skeleton>
       </TableCell>
       <TableCell verticalAlign="middle" minW="220px">
         <Skeleton loading={ isLoading } display="inline-block">
-          <HashStringShortenDynamic hash={ item.from_block_hash } noTooltip/>
+          <FluentHashValue
+            hash={ item.from_block_hash }
+            href={ route({ pathname: '/block/[height_or_hash]', query: { height_or_hash: item.from_block_hash } }) }
+          />
         </Skeleton>
       </TableCell>
       <TableCell verticalAlign="middle" minW="220px">
         <Skeleton loading={ isLoading } display="inline-block">
-          <HashStringShortenDynamic hash={ item.to_block_hash } noTooltip/>
+          <FluentHashValue
+            hash={ item.to_block_hash }
+            href={ route({ pathname: '/block/[height_or_hash]', query: { height_or_hash: item.to_block_hash } }) }
+          />
         </Skeleton>
       </TableCell>
       <TableCell verticalAlign="middle" isNumeric>

--- a/ui/txnBatches/fluent/FluentVerifierBatchStatus.tsx
+++ b/ui/txnBatches/fluent/FluentVerifierBatchStatus.tsx
@@ -16,6 +16,14 @@ const FluentVerifierBatchStatus = ({ status, isLoading }: Props) => {
     return <StatusTag type="ok" text={ status.name } loading={ isLoading }/>;
   }
 
+  if (normalized.includes('preconfirm')) {
+    return <StatusTag type="pending" text={ status.name } colorPalette="yellow" loading={ isLoading }/>;
+  }
+
+  if (normalized.includes('submitted')) {
+    return <StatusTag type="pending" text={ status.name } colorPalette="gray" loading={ isLoading }/>;
+  }
+
   if (normalized.includes('revert') || normalized.includes('invalid') || normalized.includes('fail')) {
     return <StatusTag type="error" text={ status.name } loading={ isLoading }/>;
   }


### PR DESCRIPTION
## Summary\n- shorten long batch/hash values with ellipsis in Fluent verifier batches table and mobile list\n- add copy-to-clipboard buttons for batch root, from hash, and to hash\n- make from/to block hashes clickable to open internal block pages in Blockscout\n- add explicit status tag colors: Preconfirmed (yellow), Submitted (gray)\n\n## Notes\n- follow-up to merged PR #27\n