### PR TITLE
fix(fluent): stabilize bridge table and latest-batch navigation

### DIFF
--- a/lib/api/services/verifier.ts
+++ b/lib/api/services/verifier.ts
@@ -1,4 +1,5 @@
 import type { ApiResource } from '../types';
+import type { FluentBridgeTransactionsResponse } from 'types/api/fluentBridge';
 import type { VerifierBatchesResponse } from 'types/api/verifier';
 
 export const VERIFIER_API_RESOURCES = {
@@ -7,6 +8,10 @@ export const VERIFIER_API_RESOURCES = {
     filterFields: [],
     paginated: true,
   },
+  bridge_transactions: {
+    path: '/indexer/v1/transactions',
+    filterFields: [ 'transfer_type' as const ],
+  },
 } satisfies Record<string, ApiResource>;
 
 export type VerifierApiResourceName = `verifier:${ keyof typeof VERIFIER_API_RESOURCES }`;
@@ -14,5 +19,6 @@ export type VerifierApiResourceName = `verifier:${ keyof typeof VERIFIER_API_RES
 /* eslint-disable @stylistic/indent */
 export type VerifierApiResourcePayload<R extends VerifierApiResourceName> =
 R extends 'verifier:batches' ? VerifierBatchesResponse :
+R extends 'verifier:bridge_transactions' ? FluentBridgeTransactionsResponse :
 never;
 /* eslint-enable @stylistic/indent */

--- a/ui/pages/FluentBridgeTransactionsPage.tsx
+++ b/ui/pages/FluentBridgeTransactionsPage.tsx
@@ -1,38 +1,32 @@
 import { Box, Text } from '@chakra-ui/react';
-import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import type {
   FluentBridgeTransactionItem,
-  FluentBridgeTransactionsResponse,
   FluentBridgeTransferType,
 } from 'types/api/fluentBridge';
 import type { VerifierBatchStatus } from 'types/api/verifier';
 import type { PaginationParams } from 'ui/shared/pagination/types';
 
-import config from 'configs/app';
-import useFetch from 'lib/hooks/useFetch';
+import useApiQuery from 'lib/api/useApiQuery';
 import { layerLabels } from 'lib/rollups/utils';
 import { Skeleton } from 'toolkit/chakra/skeleton';
-import { TableBody, TableCell, TableColumnHeader, TableHeaderSticky, TableRoot, TableRow } from 'toolkit/chakra/table';
+import { TableBody, TableCell, TableColumnHeader, TableHeader, TableRoot, TableRow } from 'toolkit/chakra/table';
 import { nbsp, rightLineArrow } from 'toolkit/utils/htmlEntities';
-import { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
-import CopyToClipboard from 'ui/shared/CopyToClipboard';
 import DataListDisplay from 'ui/shared/DataListDisplay';
 import BatchEntityL2 from 'ui/shared/entities/block/BatchEntityL2';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
 import TxEntityL1 from 'ui/shared/entities/tx/TxEntityL1';
-import HashStringShorten from 'ui/shared/HashStringShorten';
 import PageTitle from 'ui/shared/Page/PageTitle';
 import StickyPaginationWithText from 'ui/shared/StickyPaginationWithText';
 import TimeFormatToggle from 'ui/shared/time/TimeFormatToggle';
 import TimeWithTooltip from 'ui/shared/time/TimeWithTooltip';
+import FluentHashValue from 'ui/txnBatches/fluent/FluentHashValue';
 import FluentVerifierBatchStatus from 'ui/txnBatches/fluent/FluentVerifierBatchStatus';
 
 const PAGE_LIMIT = 50;
 const SKELETON_ROWS_COUNT = 10;
-const FLUENT_BRIDGE_TRANSACTIONS_API = `${ config.apis.verifier?.endpoint || config.apis.general.endpoint }/indexer/v1/transactions`;
 
 function formatRawAmount(amount?: string) {
   if (!amount) {
@@ -111,10 +105,7 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
     <TableRow>
       <TableCell verticalAlign="middle" minW="220px">
         { item.message_hash ? (
-          <>
-            <HashStringShorten hash={ item.message_hash } type="long"/>
-            <CopyToClipboard text={ item.message_hash }/>
-          </>
+          <FluentHashValue hash={ item.message_hash }/>
         ) : <Text color="text.secondary">-</Text> }
       </TableCell>
       <TableCell verticalAlign="middle">
@@ -152,34 +143,25 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
 };
 
 const FluentBridgeTransactionsPage = ({ transferType }: Props) => {
-  const apiFetch = useFetch();
   const [ page, setPage ] = React.useState(1);
   const offset = (page - 1) * PAGE_LIMIT;
 
-  const query = useQuery({
-    queryKey: [ 'fluent-bridge-transactions', transferType, page, PAGE_LIMIT ],
-    queryFn: async({ signal }) => {
-      const url = new URL(FLUENT_BRIDGE_TRANSACTIONS_API);
-      url.searchParams.set('transfer_type', transferType);
-      url.searchParams.set('limit', String(PAGE_LIMIT));
-      url.searchParams.set('offset', String(offset));
-
-      return apiFetch<FluentBridgeTransactionsResponse, unknown>(
-        url.toString(),
-        { signal },
-        { resource: '/indexer/v1/transactions' },
-      ) as Promise<FluentBridgeTransactionsResponse>;
-    },
-    placeholderData: {
-      items: Array.from({ length: SKELETON_ROWS_COUNT }, () => makeSkeletonItem(transferType)),
+  const { data, isError, isPlaceholderData } = useApiQuery('verifier:bridge_transactions', {
+    queryParams: {
+      transfer_type: transferType,
       limit: PAGE_LIMIT,
       offset,
-      has_more: true,
-      next_offset: offset + PAGE_LIMIT,
+    },
+    queryOptions: {
+      placeholderData: {
+        items: Array.from({ length: SKELETON_ROWS_COUNT }, () => makeSkeletonItem(transferType)),
+        limit: PAGE_LIMIT,
+        offset,
+        has_more: true,
+        next_offset: offset + PAGE_LIMIT,
+      },
     },
   });
-
-  const { data, isError, isPlaceholderData } = query;
 
   const pagination: PaginationParams = React.useMemo(() => ({
     page,
@@ -216,7 +198,7 @@ const FluentBridgeTransactionsPage = ({ transferType }: Props) => {
   const content = data?.items ? (
     <Box overflowX="auto">
       <TableRoot tableLayout="auto" minW="1320px">
-        <TableHeaderSticky top={ pagination.isVisible ? ACTION_BAR_HEIGHT_DESKTOP : 0 }>
+        <TableHeader>
           <TableRow>
             <TableColumnHeader>Message hash</TableColumnHeader>
             <TableColumnHeader>{ layerLabels.parent } txn hash</TableColumnHeader>
@@ -229,7 +211,7 @@ const FluentBridgeTransactionsPage = ({ transferType }: Props) => {
               <TimeFormatToggle/>
             </TableColumnHeader>
           </TableRow>
-        </TableHeaderSticky>
+        </TableHeader>
         <TableBody>
           { data.items.map((item, index) => (
             <FluentBridgeTransactionsTableRow

--- a/ui/pages/FluentL2TxnBatch.tsx
+++ b/ui/pages/FluentL2TxnBatch.tsx
@@ -73,8 +73,25 @@ const FluentL2TxnBatch = () => {
   const isLoading = batchQuery.isPlaceholderData;
   const isNotFound = !isLoading && !batchQuery.isError && (!batch || batch.index !== batchNumber);
 
+  const nextBatchQuery = useApiQuery<'verifier:batches', unknown, VerifierBatch | undefined>('verifier:batches', {
+    queryParams: isBatchNumberValid ? {
+      limit: PAGE_LIMIT,
+      cursor: batchNumber + 2,
+    } : undefined,
+    queryOptions: {
+      enabled: isBatchNumberValid && !isNotFound,
+      select: (response) => response.items[0],
+    },
+  });
+
+  const hasNextBatch = nextBatchQuery.data?.index === batchNumber + 1;
+
   const handlePrevNextClick = React.useCallback((direction: 'prev' | 'next') => {
     if (!isBatchNumberValid) {
+      return;
+    }
+
+    if (direction === 'next' && !hasNextBatch) {
       return;
     }
 
@@ -84,9 +101,8 @@ const FluentL2TxnBatch = () => {
     if (nextNumber < 0) {
       return;
     }
-
     router.push({ pathname: '/batches/[number]', query: { number: String(nextNumber) } }, undefined);
-  }, [ batchNumber, isBatchNumberValid, router ]);
+  }, [ batchNumber, hasNextBatch, isBatchNumberValid, router ]);
 
   return (
     <>
@@ -108,6 +124,7 @@ const FluentL2TxnBatch = () => {
               prevLabel="View previous txn batch"
               nextLabel="View next txn batch"
               isPrevDisabled={ batch.index === 0 }
+              isNextDisabled={ !hasNextBatch }
               isLoading={ isLoading }
             />
           </DetailedInfo.ItemValue>


### PR DESCRIPTION
## Summary
Fixes 3 issues reported on Fluent bridge pages:

1. **Corrupted-looking bridge table header/layout**
   - switched bridge transactions table header from sticky to regular header
   - this avoids sticky overlap artifacts in current page layout

2. **Withdrawals visibility investigation**
   - frontend query is correct (`transfer_type=withdrawal`)
   - checked backend directly:
     - `/indexer/v1/transactions?transfer_type=withdrawal&limit=1&offset=0` returns empty items
     - scanning `transfer_type=all` currently returns only deposits (no `withdrawal`, no `l2_to_l1`)
   - so this is **backend/indexing data issue**, not a frontend filter bug

3. **Last batch still enables Next and opens unknown error**
   - batch details page now checks whether `N+1` exists before enabling Next
   - Next is disabled on latest batch, preventing navigation to invalid page/error

## Technical changes
- Added verifier API resource for bridge transactions:
  - `verifier:bridge_transactions` -> `/indexer/v1/transactions`
- Bridge transactions page now uses `useApiQuery('verifier:bridge_transactions')` (same verifier/proxy flow)
- Batch details page (`/batches/[number]`, Fluent) now performs next-batch existence check via verifier API.

## Validation
- `npx eslint ui/pages/FluentBridgeTransactionsPage.tsx ui/pages/FluentL2TxnBatch.tsx lib/api/services/verifier.ts`
- `yarn lint:tsc`
