### PR TITLE
feat(fluent): display token symbol and decimal-formatted amount

### DIFF
--- a/types/api/fluentBridge.ts
+++ b/types/api/fluentBridge.ts
@@ -11,6 +11,9 @@ export type FluentBridgeTransactionItem = {
   receiver_gateway: string;
   asset_type: string;
   amount: string;
+  token_name: string | null;
+  token_symbol: string | null;
+  token_decimals: number | null;
   l1_tx_hash: string | null;
   l2_tx_hash: string | null;
   sent_tx_hash: string | null;

--- a/ui/pages/FluentBridgeTransactionsPage.tsx
+++ b/ui/pages/FluentBridgeTransactionsPage.tsx
@@ -21,6 +21,7 @@ import PageTitle from 'ui/shared/Page/PageTitle';
 import StickyPaginationWithText from 'ui/shared/StickyPaginationWithText';
 import TimeFormatToggle from 'ui/shared/time/TimeFormatToggle';
 import TimeWithTooltip from 'ui/shared/time/TimeWithTooltip';
+import AssetValue from 'ui/shared/value/AssetValue';
 import NativeCoinValue from 'ui/shared/value/NativeCoinValue';
 import FluentHashValue from 'ui/txnBatches/fluent/FluentHashValue';
 import FluentVerifierBatchStatus from 'ui/txnBatches/fluent/FluentVerifierBatchStatus';
@@ -44,6 +45,9 @@ function makeSkeletonItem(transferType: FluentBridgeTransferType): FluentBridgeT
     receiver_gateway: '',
     asset_type: '',
     amount: '0',
+    token_name: null,
+    token_symbol: null,
+    token_decimals: null,
     l1_tx_hash: null,
     l2_tx_hash: null,
     sent_tx_hash: null,
@@ -89,6 +93,20 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
     name: item.batch_status_name,
   } : null;
 
+  const amountContent = (() => {
+    if (item.asset_type === 'token') {
+      const symbol = item.token_symbol || undefined;
+
+      if (typeof item.token_decimals === 'number') {
+        return <AssetValue amount={ item.amount } decimals={ item.token_decimals } asset={ symbol } noTooltip/>;
+      }
+
+      return <AssetValue amount={ item.amount } decimals={ 0 } asset={ symbol } noTooltip/>;
+    }
+
+    return <NativeCoinValue amount={ item.amount } noSymbol/>;
+  })();
+
   return (
     <TableRow>
       <TableCell verticalAlign="middle" minW="220px">
@@ -111,7 +129,7 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
         ) }
       </TableCell>
       <TableCell verticalAlign="middle" isNumeric>
-        <NativeCoinValue amount={ item.amount } noSymbol/>
+        { amountContent }
       </TableCell>
       <TableCell verticalAlign="middle">
         { typeof item.batch_index === 'number' ? (

--- a/ui/pages/FluentBridgeTransactionsPage.tsx
+++ b/ui/pages/FluentBridgeTransactionsPage.tsx
@@ -101,7 +101,7 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
         return <AssetValue amount={ item.amount } decimals={ item.token_decimals } asset={ symbol } noTooltip/>;
       }
 
-      return <AssetValue amount={ item.amount } decimals={ 0 } asset={ symbol } noTooltip/>;
+      return <AssetValue amount={ item.amount } decimals={ 18 } asset={ symbol } noTooltip/>;
     }
 
     return <NativeCoinValue amount={ item.amount } noSymbol/>;


### PR DESCRIPTION
## Summary
- show token symbol in Fluent L1/L2 deposits and withdrawals tabs
- format token amount using `token_decimals` from API response

## Changes
- `types/api/fluentBridge.ts`
  - added `token_name`, `token_symbol`, `token_decimals` to bridge transaction item type
- `ui/pages/FluentBridgeTransactionsPage.tsx`
  - for `asset_type=token`, render amount with `AssetValue` using response `token_decimals`
  - include `token_symbol` in rendered amount
  - keep native-asset rows rendered via existing `NativeCoinValue`

## Validation
- `npx eslint types/api/fluentBridge.ts ui/pages/FluentBridgeTransactionsPage.tsx`
- `yarn lint:tsc`
