### PR TITLE
fix(fluent): render bridge amount from token fields in API response

### DIFF
--- a/types/api/fluentBridge.ts
+++ b/types/api/fluentBridge.ts
@@ -11,6 +11,9 @@ export type FluentBridgeTransactionItem = {
   receiver_gateway: string;
   asset_type: string;
   amount: string;
+  token_name: string | null;
+  token_symbol: string | null;
+  token_decimals: number | null;
   l1_tx_hash: string | null;
   l2_tx_hash: string | null;
   sent_tx_hash: string | null;

--- a/ui/pages/FluentBridgeTransactionsPage.tsx
+++ b/ui/pages/FluentBridgeTransactionsPage.tsx
@@ -21,6 +21,7 @@ import PageTitle from 'ui/shared/Page/PageTitle';
 import StickyPaginationWithText from 'ui/shared/StickyPaginationWithText';
 import TimeFormatToggle from 'ui/shared/time/TimeFormatToggle';
 import TimeWithTooltip from 'ui/shared/time/TimeWithTooltip';
+import AssetValue from 'ui/shared/value/AssetValue';
 import NativeCoinValue from 'ui/shared/value/NativeCoinValue';
 import FluentHashValue from 'ui/txnBatches/fluent/FluentHashValue';
 import FluentVerifierBatchStatus from 'ui/txnBatches/fluent/FluentVerifierBatchStatus';
@@ -44,6 +45,9 @@ function makeSkeletonItem(transferType: FluentBridgeTransferType): FluentBridgeT
     receiver_gateway: '',
     asset_type: '',
     amount: '0',
+    token_name: null,
+    token_symbol: null,
+    token_decimals: null,
     l1_tx_hash: null,
     l2_tx_hash: null,
     sent_tx_hash: null,
@@ -89,6 +93,21 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
     name: item.batch_status_name,
   } : null;
 
+  const amountContent = (() => {
+    if (item.asset_type === 'token' || item.token_symbol || typeof item.token_decimals === 'number') {
+      return (
+        <AssetValue
+          amount={ item.amount }
+          decimals={ typeof item.token_decimals === 'number' ? item.token_decimals : 18 }
+          asset={ item.token_symbol || undefined }
+          noTooltip
+        />
+      );
+    }
+
+    return <NativeCoinValue amount={ item.amount } noSymbol/>;
+  })();
+
   return (
     <TableRow>
       <TableCell verticalAlign="middle" minW="220px">
@@ -111,7 +130,7 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
         ) }
       </TableCell>
       <TableCell verticalAlign="middle" isNumeric>
-        <NativeCoinValue amount={ item.amount } noSymbol/>
+        { amountContent }
       </TableCell>
       <TableCell verticalAlign="middle">
         { typeof item.batch_index === 'number' ? (


### PR DESCRIPTION
## Summary
Use token metadata fields from bridge API response in deposits/withdrawals amount rendering.

## Changes
- Added bridge response fields to TS type:
  - `token_name`
  - `token_symbol`
  - `token_decimals`
- Amount cell now uses API token fields:
  - formats by `token_decimals` (fallback `18`)
  - displays `token_symbol` when present

## Notes
- This applies to `asset_type=token` rows and also rows where API provides token fields.
- Native rows without token fields keep existing native formatting path.

## Validation
- `npx eslint types/api/fluentBridge.ts ui/pages/FluentBridgeTransactionsPage.tsx`
- `yarn lint:tsc`
