### PR TITLE
fix(fluent): render bridge amount from token fields in API response

### DIFF
--- a/ui/pages/FluentBridgeTransactionsPage.tsx
+++ b/ui/pages/FluentBridgeTransactionsPage.tsx
@@ -94,14 +94,15 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
   } : null;
 
   const amountContent = (() => {
-    if (item.asset_type === 'token') {
-      const symbol = item.token_symbol || undefined;
-
-      if (typeof item.token_decimals === 'number') {
-        return <AssetValue amount={ item.amount } decimals={ item.token_decimals } asset={ symbol } noTooltip/>;
-      }
-
-      return <AssetValue amount={ item.amount } decimals={ 18 } asset={ symbol } noTooltip/>;
+    if (item.asset_type === 'token' || item.token_symbol || typeof item.token_decimals === 'number') {
+      return (
+        <AssetValue
+          amount={ item.amount }
+          decimals={ typeof item.token_decimals === 'number' ? item.token_decimals : 18 }
+          asset={ item.token_symbol || undefined }
+          noTooltip
+        />
+      );
     }
 
     return <NativeCoinValue amount={ item.amount } noSymbol/>;


### PR DESCRIPTION
## Summary
Use API response token fields in Fluent bridge deposits/withdrawals UI.

## Changes
- reads `token_symbol` for asset label in amount column
- formats amount with `token_decimals` from API (fallback `18`)
- extends `FluentBridgeTransactionItem` with:
  - `token_name`
  - `token_symbol`
  - `token_decimals`

## Validation
- `npx eslint types/api/fluentBridge.ts ui/pages/FluentBridgeTransactionsPage.tsx`
- `yarn lint:tsc`