### PR TITLE
fix(fluent): show withdrawal bridge token amounts

### DIFF
--- a/ui/pages/FluentBridgeTransactionsPage.tsx
+++ b/ui/pages/FluentBridgeTransactionsPage.tsx
@@ -94,18 +94,20 @@ const FluentBridgeTransactionsTableRow = ({ item, isLoading }: { item: FluentBri
   } : null;
 
   const amountContent = (() => {
-    if (item.asset_type === 'token' || item.token_symbol || typeof item.token_decimals === 'number') {
+    const amount = item.amount ?? item.value;
+
+    if (item.asset_type === 'token' || item.token_symbol || item.token_name || typeof item.token_decimals === 'number') {
       return (
         <AssetValue
-          amount={ item.amount }
+          amount={ amount }
           decimals={ typeof item.token_decimals === 'number' ? item.token_decimals : 18 }
-          asset={ item.token_symbol || undefined }
+          asset={ item.token_symbol || item.token_name || undefined }
           noTooltip
         />
       );
     }
 
-    return <NativeCoinValue amount={ item.amount } noSymbol/>;
+    return <NativeCoinValue amount={ amount }/>;
   })();
 
   return (


### PR DESCRIPTION
## Summary\n- reuse the API token metadata path for Fluent bridge withdrawals\n- fall back to the bridge value when amount is absent\n- show the native currency symbol instead of rendering native withdrawals without a symbol\n\n## Tests\n- yarn lint:tsc\n- yarn lint:eslint ui/pages/FluentBridgeTransactionsPage.tsx